### PR TITLE
feat(GUI): add default colors on Status column

### DIFF
--- a/index.php
+++ b/index.php
@@ -125,7 +125,7 @@ for ( $i = 0 ; $i < sizeof($servers) ; $i++ ) {
 			 $lmgrdversion));
 
 	# Set the background color of status cell
-	$table->updateCellAttributes( ($table->getRowCount() - 1) , 3, "class='" . $class . "'");
+	$table->updateCellAttributes( ($table->getRowCount() - 1) , 2, "class='" . $class . "'");
 	//$table->updateCellAttributes( 1 , 0, "");
 
 	# Close the pipe

--- a/style.css
+++ b/style.css
@@ -2,3 +2,14 @@
     margin-top: 50px;
 }
 
+td.up{
+    background-color:green;
+}
+
+td.down{
+    color:red;
+}
+
+td.warning{
+    color:orange;
+}


### PR DESCRIPTION
Add green/yellow/red default color for serveurs status
Change column where color is applied from "Current Usage" to "Status" :
- more logical
- Ugly when "Details" link has a backgound color on it