### PR TITLE
Pear DB added to composer

### DIFF
--- a/check_installation.php
+++ b/check_installation.php
@@ -5,29 +5,53 @@ include_once('DB.php');
 include_once('HTML/Table.php');
 
 define("PASS_MARK", "<span class='green-text'>&#10004; GOOD</span>");  // green heavy checkmark
-define("FAIL_MARK", "<span class='red-text'>&#10006; FAIL</span>");  // red cross mark
-define("REQUIRED_PHP", 50300);  // PHP 5.3.0
+define("FAIL_MARK", "<span class='red-text'>&#10006; FAIL</span>");    // red cross mark
+define("REQUIRED_PHP", "5.3.0");
 
-$test     = PHP_VERSION_ID > REQUIRED_PHP;
-$php_val  = phpversion();
-$php_mark = $test ? PASS_MARK : FAIL_MARK;
+// Parallel arrays
+$test_names   = array();
+$test_values  = array();
+$test_results = array();
 
-$test    = function_exists("imagecreate");
-$gd_val  = $test ? "Installed" : "Not installed";
-$gd_mark = $test ? PASS_MARK : FAIL_MARK;
+// Calculate minimum php version id for first test.
+$ver = explode(".", REQUIRED_PHP);
+$minimum_php_version_id = $ver[0] * 10000 + $ver[1] * 100 + $ver[2];
+
+$test           = PHP_VERSION_ID >= $minimum_php_version_id;
+$test_names[]   = "PHP Version At Least " . REQUIRED_PHP;
+$test_values[]  = phpversion();
+$test_results[] = $test ? PASS_MARK : FAIL_MARK;
 
 // TO DO: Expand this test to validate config.php values.
-$test        = is_readable("config.php");
-$config_val  = $test ? "Readable" : "Not Readable";
-$config_mark = $test ? PASS_MARK : FAIL_MARK;
+$test           = is_readable("config.php");
+$test_names[]   = "<code>config.php</code>";
+$test_values[]  = $test ? "Readable" : "Not Readable";
+$test_results[] = $test ? PASS_MARK : FAIL_MARK;
 
-$test       = class_exists("HTML_Table");
-$table_val  = $test ? "Installed" : "Not Installed";
-$table_mark = $test ? PASS_MARK : FAIL_MARK;
+$test           = extension_loaded("gd");
+$test_names[]   = "PHP Extension \"gd\" (required for graphs)";
+$test_values[]  = $test ? "Installed and Enabled" : "Not Found";
+$test_results[] = $test ? PASS_MARK : FAIL_MARK;
 
-$test        = is_executable($lmutil_loc);
-$lmutil_val  = $test ? "Is Executable" : "Not Executable (maybe check permissions?)";
-$lmutil_mark = $test ? PASS_MARK : FAIL_MARK;
+$test           = extension_loaded("xml");
+$test_names[]   = "PHP Extension \"xml\" (required by pear DB class)";
+$test_values[]  = $test ? "Installed and Enabled" : "Not Found";
+$test_results[] = $test ? PASS_MARK : FAIL_MARK;
+
+$test           = class_exists("HTML_Table");
+$test_names[]   = "Pear HTML Table Class";
+$test_values[]  = $test ? "Installed" : "Not Found";
+$test_results[] = $test ? PASS_MARK : FAIL_MARK;
+
+$test           = class_exists("DB");
+$test_names[]   = "Pear DB Class";
+$test_values[]  = $test ? "Installed" : "Not Found";
+$test_results[] = $test ? PASS_MARK : FAIL_MARK;
+
+$test           = isset($lmutil_loc) && is_executable($lmutil_loc);
+$test_names[]   = "<code>lmutil</code>";
+$test_values[]  = $test ? "Is Executable" : "Not Executable (maybe check permissions?)";
+$test_results[] = $test ? PASS_MARK : FAIL_MARK;
 
 $test = (bool) function() {
     if (isset($db_hostname) && isset($db_username) && isset($db_password)) {
@@ -37,9 +61,24 @@ $test = (bool) function() {
 
     return false;
 };
-$db_val  = $test ? "Connection OK" : "Connection Failed.";
-$db_mark = $test ? PASS_MARK : FAIL_MARK;
+$test_names[]   = "Database Connectivity";
+$test_values[]  = $test ? "Connection OK" : "Connection Failed.";
+$test_results[] = $test ? PASS_MARK : FAIL_MARK;
 
+// Build rows for test results table.
+$test_table_rows = "";
+foreach ($test_names as $i => $test_name) {
+    $test_table_rows .= <<< HTML
+    <tr>
+        <td>{$test_name}</td>
+        <td>{$test_values[$i]}</td>
+        <td>{$test_results[$i]}</td>
+    </tr>
+
+HTML;
+}
+
+// Display view.
 print_header();
 
 print <<< HTML
@@ -48,38 +87,15 @@ print <<< HTML
 
 <p>This will check whether PHPlicensewatcher has been properly installed.
 This is not an exhaustive check but checks for common installation and configuration issues.</p>
-
-<table id="install-check">
+<table id='install-check'>
     <tr>
         <th>TEST</th>
         <th>VALUE</th>
         <th>RESULT</th>
-    </tr><tr>
-        <td>PHP Version</td>
-        <td>{$php_val}</td>
-        <td>{$php_mark}</td>
-    </tr><tr>
-        <td>Config File</td>
-        <td>{$config_val}</td>
-        <td>{$config_mark}</td>
-    </tr><tr>
-        <td>GD Support for Graphs</td>
-        <td>{$gd_val}</td>
-        <td>{$gd_mark}</td>
-    </tr><tr>
-        <td>Pear HTML Table Class</td>
-        <td>{$table_val}</td>
-        <td>{$table_mark}</td>
-    </tr><tr>
-        <td><code>{$lmutil_loc}</code></td>
-        <td>{$lmutil_val}</td>
-        <td>{$lmutil_mark}</td>
-    </tr><tr>
-        <td>Database Connectivity</td>
-        <td>{$db_val}</td>
-        <td>{$db_mark}</td>
     </tr>
+{$test_table_rows}
 </table>
+
 HTML;
 
 print_footer();

--- a/composer.json
+++ b/composer.json
@@ -5,6 +5,7 @@
     }],
 
     "require": {
-        "pear-pear.php.net/html_table": "^1.8.4"
+        "pear-pear.php.net/html_table": "^1.8.4",
+        "pear-pear.php.net/db": "^1.9.3"
     }
 }

--- a/vagrant_provision/pl/provision.pl
+++ b/vagrant_provision/pl/provision.pl
@@ -21,7 +21,7 @@ my @HTML_PATH = (rootdir(), "var", "www", "html");
 my @APACHE_PATH = (rootdir(), "etc", "apache2");
 
 # Packages needed by OS
-my @REQUIRED_PACKAGES = ("apache2", "php", "php-gd", "php-db", "php-mysql", "mysql-server", "mysql-client", "lsb", "composer");
+my @REQUIRED_PACKAGES = ("apache2", "php", "php-xml", "php-gd", "php-mysql", "mysql-server", "mysql-client", "lsb", "composer");
 
 # Non super user account.  Some package systems run better when not as root.
 my $NOT_SUPERUSER = "vagrant";


### PR DESCRIPTION
- Pear DB added to `composer.json` for better portability.
    - Previously installed pear DB via Ubuntu aptitude.
- Vagrant box provision updated accordingly.
- Check Install tests updated.
    - Although we plan on deprecating pear DB, it does require php extension 'xml' for while we are using it.
- Check Install code improved
   -  Test results table is a bit more robust.
   -  Test results rendering is logically produced rather than dictated HTML.