### PR TITLE
Vagrant provision updates for file cache and error logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,8 @@ lmutil
 **/*~
 
 # Logs
+/logs/**
+!/logs/readme.txt
 *.log
 
 # Compiled source

--- a/logs/readme.txt
+++ b/logs/readme.txt
@@ -1,0 +1,2 @@
+Debug logs generated within the vagrant box will appear here.
+These logs should not be tracked in Github.

--- a/tools.php
+++ b/tools.php
@@ -1,7 +1,7 @@
 <?php
 
 ################################################################################################
-# This build 
+# This build
 ################################################################################################
 function build_license_expiration_array($lmutil_loc, $server, &$expiration_array) {
 
@@ -13,7 +13,7 @@ function build_license_expiration_array($lmutil_loc, $server, &$expiration_array
 
   # Let's read in the file line by line
   while (!feof ($file)) {
-    
+
     $line = fgets ($file, 1024);
 
     if ( preg_match("/INCREMENT .*/i", $line, $out ) || preg_match("/FEATURE .*/i", $line, $out ) ) {
@@ -33,17 +33,17 @@ function build_license_expiration_array($lmutil_loc, $server, &$expiration_array
         $license[4] = str_replace("-0", "-2036", $license[4]);
 	$license[4] = str_replace("permanent", "05-jul-2036", $license[4]);
         $unixdate2 = strtotime($license[4]);
-        
+
         # Convert the date you got into UNIX time
         $unixdate2 = strtotime($license[4]);
 	}
-	
-	
+
+
     $days_to_expiration = ceil ((1 + strtotime($license[4]) - $today) / 86400);
 
     ##############################################################################
     # If there is more than 4000 days = 10 years+ until expiration I will
-    # consider the license to be permanent 
+    # consider the license to be permanent
     ##############################################################################
     if ( $days_to_expiration > 4000 ) {
         $license[4] = "permanent";
@@ -61,13 +61,13 @@ function build_license_expiration_array($lmutil_loc, $server, &$expiration_array
 
 
   }
-  
+
   #echo("<pre>");
   #print_r($expiration_array);
 
 
   pclose($file);
-  
+
   return 1;
 }
 
@@ -154,14 +154,14 @@ be checked
 ##################################################################
 function num_licenses_available($myfeature) {
 
-    global $servers, $lmutil_loc; 
+    global $servers, $lmutil_loc;
 
     $LICENSE_FILE="";
-    
+
     # Build LM_LICENSE_FILE
    for ( $i = 0 ; $i < sizeof($servers); $i++ )
         $LICENSE_FILE .= $servers[$i] . ":";
-   
+
    $fp = popen($lmutil_loc . " lmstat -f " . $myfeature  . " -c " . $LICENSE_FILE, "r");
 
    while ( !feof ($fp) ) {
@@ -178,7 +178,7 @@ function num_licenses_available($myfeature) {
 	}
 
    }
-    
+
 }
 
 ##################################################################
@@ -187,14 +187,14 @@ function num_licenses_available($myfeature) {
 ##################################################################
 function num_licenses_used($myfeature) {
 
-    global $servers, $lmstat_loc; 
+    global $servers, $lmstat_loc;
 
     $LICENSE_FILE="";
-    
+
     # Build LM_LICENSE_FILE
    for ( $i = 0 ; $i < sizeof($servers); $i++ )
         $LICENSE_FILE .= $servers[$i] . ":";
-   
+
    $fp = popen($lmstat_loc . " -f " . $myfeature  . " -c " . $LICENSE_FILE, "r");
 
     $num_licenses = 0;
@@ -213,7 +213,7 @@ function num_licenses_used($myfeature) {
     pclose($fp);
 
     return $num_licenses;
-    
+
 }
 
 
@@ -287,7 +287,7 @@ class timespan
     function timespan($after,$before)
         {
         # Set variables to zero, instead of null.
-        
+
         $this->years = 0;
         $this->months = 0;
         $this->weeks = 0;
@@ -311,7 +311,7 @@ class timespan
             $this->years += 1;
             $duration -= (int)$year;
             $dec -= (int)$year;
-            
+
             $year = $this->leap($dec);
             }
 
@@ -357,11 +357,11 @@ class timespan
 
 function run_command( $command ){
     global $lmutil_loc;
-    
+
     $data = "";
-    
+
     if( !cache_check($command, $data) ){
-   
+
         $fp = popen( $command , "r");
 
         $data = "";
@@ -369,49 +369,38 @@ function run_command( $command ){
             $data .= fgets ($fp, 1024);
         }
         pclose($fp);
-    
+
         cache_store( $command , $data );
-        
+
     }
-    
+
     return $data;
 }
 
-
-
-
-function cache_check( $command , &$data ){
+function cache_check($command , &$data) {
+    global $cache_dir;
     $result = false;
-    
-    $cache_dir = '/tmp/';
-    $hash = md5( $command );
-    $cacheFile = $cache_dir . $hash ;
-    
-    if( file_exists( $cacheFile ) ){
-        
+    $hash = md5($command);
+    $cacheFile = $cache_dir . $hash;
+
+    if (file_exists($cacheFile)){
         if (time()-filemtime($cacheFile) > 2 * 3600) {
-          // file older than 2 hours
+            // file older than 2 hours
         } else {
-          // file younger than 2 hours
+            // file younger than 2 hours
             $data = file_get_contents($cacheFile);
             $result = true;
         }
-        
     }
-    
+
     return $result;
-    
 }
 
 function cache_store( $command , $data ){
-    
-     $cache_dir = '/tmp/';
+    global $cache_dir;
     $hash = md5( $command );
     $cacheFile = $cache_dir . $hash ;
-    
     file_put_contents($cacheFile, $data );
-    
 }
-
 
 ?>

--- a/vagrant_provision/README.md
+++ b/vagrant_provision/README.md
@@ -51,7 +51,7 @@ You may develop code for this repository on your host.  Make sure the VM is runn
     * Virtualbox typically assigns the VM an IP of `10.0.2.15`.  This is not visible from the host due to Virtualbox's NAT firewall.  Instead, certain ports are forwarded to the host at `localhost`.
     * Virtualbox's NAT firewall is meant to block connections to the VM from the Internet.
     * Your host can be seen from within the VM at `10.0.2.2`.
-* Server statuses (shown on `index.php`) get cached for two hours.  Should this cache go stale before expiration, you can delete all cache files within the vagrant box.  The path and files are `/var/cache/phplw/*.cache`
+* Server statuses (shown on `index.php`) get cached for two hours.  Should this cache go stale before expiration, you can delete all of the cache files with `vagrant up --provision-with delete-cache`.
 
 ### Troubleshooting
 * Many problems can be solved by issuing a "full-update". `vagrant up --provision-with full-update`
@@ -71,6 +71,7 @@ Command | Purpose
 `vagrant up --provision-with update` | Update the VM with your latest code.  You'll also have to refresh your web browser.
 `vagrant up --provision-with full-update` | Remove all code and packages from guest.  Reinstall development code from working branch.  Reinstall composer packages.  Reinstall provision configuration file.  Do this only if you need a complete reset.
 `vagrant up --provision-with composer-update` | Checks composer for&mdash;and installs&mdash;all updates to packages.
+`vagrant up --provision-with delete-cache` | Removes all server status cache files.  Do this if the cache goes stale.
 `vagrant ssh` | Opens a secure shell connection to the VM.
 
 ### Forwarded Ports

--- a/vagrant_provision/README.md
+++ b/vagrant_provision/README.md
@@ -24,7 +24,7 @@ Download and install for your operating system:
 3. Go to the root folder of the cloned repository.
 4. On the command line: `vagrant up`
     * There will be a long series of build messages printed to the console.
-    * Build messages will be logged in the repository at `.vagrant/provision.log` (not tracked by git).
+    * Build messages will be logged in the repository at `logs/provision.log` (not tracked by git).
     * Depending on the speed of your Internet connection and the speed of your host computer, it can take 30 minutes or more to build the VM.
     * Once the VM is built, it doesn't take nearly as long to start up the VM another time.
 
@@ -41,6 +41,7 @@ You may develop code for this repository on your host.  Make sure the VM is runn
 * You can view the VM server webpage at `http://localhost:50080`
 * A MySQL database viewer can connect to the VM server at `localhost`, port `53306`.
     * MySQL Workbench can connect to the VM server with user and password as `vagrant`.  Database Schema is also `vagrant`.
+* Should Apache generate a 500 error, the error will be logged to `phplw_errors.log` which can be viewed from within the `logs` folder in this repository (log files should be rotated by the vagrant box, but are not tracked by git).
 
 ### Tips and Tricks
 * You can use secure copy ('scp') to upload a file to the VM without it being tracked by git:<br />
@@ -51,7 +52,6 @@ You may develop code for this repository on your host.  Make sure the VM is runn
     * Virtualbox's NAT firewall is meant to block connections to the VM from the Internet.
     * Your host can be seen from within the VM at `10.0.2.2`.
 * Server statuses (shown on `index.php`) get cached for two hours.  Should this cache go stale before expiration, you can delete all cache files within the vagrant box.  The path and files are `/var/cache/phplw/*.cache`
-* The PHP error log is within the Vagrant box at `/var/log/apache2/phplw_error.log`.
 
 ### Troubleshooting
 * Many problems can be solved by issuing a "full-update". `vagrant up --provision-with full-update`

--- a/vagrant_provision/README.md
+++ b/vagrant_provision/README.md
@@ -50,6 +50,8 @@ You may develop code for this repository on your host.  Make sure the VM is runn
     * Virtualbox typically assigns the VM an IP of `10.0.2.15`.  This is not visible from the host due to Virtualbox's NAT firewall.  Instead, certain ports are forwarded to the host at `localhost`.
     * Virtualbox's NAT firewall is meant to block connections to the VM from the Internet.
     * Your host can be seen from within the VM at `10.0.2.2`.
+* Server statuses (shown on `index.php`) get cached for two hours.  Should this cache go stale before expiration, you can delete all cache files within the vagrant box.  The path and files are `/var/cache/phplw/*.cache`
+* The PHP error log is within the Vagrant box at `/var/log/apache2/phplw_error.log`.
 
 ### Troubleshooting
 * Many problems can be solved by issuing a "full-update". `vagrant up --provision-with full-update`

--- a/vagrant_provision/apache/phplw.conf
+++ b/vagrant_provision/apache/phplw.conf
@@ -6,8 +6,8 @@
     AddHandler php7-script .php
     AddType text/html .php
 
-    ErrorLog ${APACHE_LOG_DIR}/phplw_error.log
-    CustomLog ${APACHE_LOG_DIR}/phplw_access.log combined
+    ErrorLog /home/vagrant/github_phplw/logs/phplw_error.log
+    CustomLog /home/vagrant/github_phplw/logs/phplw_access.log combined
 
     <Directory />
         Require all denied

--- a/vagrant_provision/config/config.php
+++ b/vagrant_provision/config/config.php
@@ -2,6 +2,7 @@
 // Config file for Vagrant VM
 $lmutil_loc="/opt/flexnetserver/lmutil";
 $lmstat_loc="{$lmutil_loc} lmstat";
+$cache_dir="/var/cache/phplw/";
 $notify_address="";
 $lead_time=30;
 $disable_autorefresh=0;

--- a/vagrant_provision/logrotate/phplw.conf
+++ b/vagrant_provision/logrotate/phplw.conf
@@ -1,0 +1,15 @@
+/home/vagrant/github_phplw/logs/phplw*.log {
+    weekly
+    create 0644 root root
+    rotate 10
+    size 1M
+    compress
+    delaycompress
+    compresscmd zip
+    uncompresscmd unzip
+    compressoptions -9
+    missingok
+    notifempty
+    noshred
+    nomail
+}

--- a/vagrant_provision/logrotate/phplw.conf
+++ b/vagrant_provision/logrotate/phplw.conf
@@ -1,6 +1,7 @@
 /home/vagrant/github_phplw/logs/phplw*.log {
+    su vagrant vagrant
     weekly
-    create 0644 root root
+    create 0664 vagrant vagrant
     rotate 10
     size 1M
     compress

--- a/vagrant_provision/pl/provision.pl
+++ b/vagrant_provision/pl/provision.pl
@@ -20,6 +20,7 @@ print STDERR "Root required.\n" and exit 1 if ($> != 0);
 my @REPO_PATH = (rootdir(), "home", "vagrant", "github_phplw");
 my @FLEXNETSERVER_PATH = (rootdir(), "opt", "flexnetserver");
 my @HTML_PATH = (rootdir(), "var", "www", "html");
+my @LOGROTATE_PATH = (rootdir(), "etc", "logrotate.d");
 my @APACHE_PATH = (rootdir(), "etc", "apache2");
 my @CACHE_PATH = (rootdir(), "var", "cache", "phplw");
 
@@ -54,7 +55,8 @@ my $DB_PASS = "vagrant";
 
 # Other relevant files
 my $SQL_FILE = "phplicensewatcher.sql";
-my $CONF_FILE = "phplw.conf";
+my $LOGROTATE_CONF_FILE = "phplw.conf";
+my $APACHE_CONF_FILE = "phplw.conf";
 my $UPDATE_CODE = "update_code.pl";
 
 # IP address to bind MySQL to.
@@ -173,6 +175,14 @@ exec_cmd("mysql -e \"FLUSH PRIVILEGES;\"");
 $file = catfile(@REPO_PATH, $SQL_FILE);
 exec_cmd("mysql --user=$DB_USER --password=$DB_PASS --database=$DB_NAME < $file");
 
+# Setup logrotate for Apache error logs on the host.
+print "Setup logrotate for apache logs viewable on host\n";
+@source_path = (@REPO_PATH, "vagrant_provision", "logrotate");
+@dest_path   = @LOGROTATE_PATH;
+$source = catfile(@source_path, $LOGROTATE_CONF_FILE);
+$dest   = catfile(@dest_path, $LOGROTATE_CONF_FILE);
+copy $source, $dest;
+
 # Setup apache conf
 # First disable all currently active conf files
 print "Setting up Apache2\n";
@@ -187,12 +197,12 @@ foreach (glob($files)) {
 # Copy phpLicenseWatcher conf file
 @source_path = (@REPO_PATH, "vagrant_provision", "apache");
 @dest_path   = (@APACHE_PATH, "sites-available");
-$source = catfile(@source_path, $CONF_FILE);
-$dest   = catfile(@dest_path, $CONF_FILE);
+$source = catfile(@source_path, $APACHE_CONF_FILE);
+$dest   = catfile(@dest_path, $APACHE_CONF_FILE);
 copy $source, $dest;
 
-# Activate phpLicenseWatcher conf file
-$conf = $CONF_FILE;
+# Activate phpLicenseWatcher Apache conf file
+$conf = $APACHE_CONF_FILE;
 $conf =~ s{\.[^.]+$}{};  # Removes ".conf" extension
 exec_cmd("a2ensite $conf");
 exec_cmd("apachectl restart");

--- a/vagrant_provision/pl/provision.pl
+++ b/vagrant_provision/pl/provision.pl
@@ -21,6 +21,7 @@ my @REPO_PATH = (rootdir(), "home", "vagrant", "github_phplw");
 my @FLEXNETSERVER_PATH = (rootdir(), "opt", "flexnetserver");
 my @HTML_PATH = (rootdir(), "var", "www", "html");
 my @APACHE_PATH = (rootdir(), "etc", "apache2");
+my @CACHE_PATH = (rootdir(), "var", "cache", "phplw");
 
 # Packages needed by OS
 my @REQUIRED_PACKAGES = ("apache2", "php", "php-xml", "php-gd", "php-mysql", "mysql-server", "mysql-client", "lsb", "composer");
@@ -30,7 +31,13 @@ my $NOT_SUPERUSER = "vagrant";
 my $NOT_SUPERUSER_UID = getpwnam $NOT_SUPERUSER;
 my $NOT_SUPERUSER_GID = getgrnam $NOT_SUPERUSER;
 
-# List of Flex LM binaries
+# Cache files owner
+my $CACHE_OWNER = "www-data";
+my $CACHE_OWNER_UID = getpwnam $CACHE_OWNER;
+my $CACHE_OWNER_GID = getgrnam $CACHE_OWNER;
+my $CACHE_PERMISSIONS = 0700;
+
+# List of Flex LM binaries and ownership
 my @FLEXLM_FILES = ("adskflex", "lmgrd", "lmutil");
 my $FLEXLM_OWNER = "www-data";
 my $FLEXLM_OWNER_UID = getpwnam $FLEXLM_OWNER;
@@ -86,6 +93,12 @@ foreach (@REQUIRED_PACKAGES) {
 # Run composer to retrieve PHP dependencies
 # Composer cannot be run as superuser.
 exec_cmd("su -c \"composer -d" . catfile(@REPO_PATH) . " install\" $NOT_SUPERUSER");
+
+# Prepare cache directory
+$dest = catdir(@CACHE_PATH);
+mkdir $dest, 0701;
+chown $CACHE_OWNER_UID, $CACHE_OWNER_GID, $dest;
+print "Created cache file directory: $dest\n";
 
 # Copy Flex LM files to system.
 @source_path = (@REPO_PATH, "vagrant_provision", "flex_lm");

--- a/vagrant_provision/pl/provision.pl
+++ b/vagrant_provision/pl/provision.pl
@@ -23,8 +23,8 @@ my @HTML_PATH = (rootdir(), "var", "www", "html");
 my @APACHE_PATH = (rootdir(), "etc", "apache2");
 my @CACHE_PATH = (rootdir(), "var", "cache", "phplw");
 
-# Packages needed by OS
-my @REQUIRED_PACKAGES = ("apache2", "php", "php-xml", "php-gd", "php-mysql", "mysql-server", "mysql-client", "lsb", "composer");
+# Packages needed for phplw.
+my @REQUIRED_PACKAGES = ("apache2", "php", "php-xml", "php-gd", "php-mysql", "mysql-server", "mysql-client", "lsb", "composer", "zip", "unzip");
 
 # Non super user account.  Some package systems run better when not as root.
 my $NOT_SUPERUSER = "vagrant";

--- a/vagrant_provision/pl/provision.pl
+++ b/vagrant_provision/pl/provision.pl
@@ -182,6 +182,7 @@ print "Setup logrotate for apache logs viewable on host\n";
 $source = catfile(@source_path, $LOGROTATE_CONF_FILE);
 $dest   = catfile(@dest_path, $LOGROTATE_CONF_FILE);
 copy $source, $dest;
+print "\n";
 
 # Setup apache conf
 # First disable all currently active conf files

--- a/vagrantfile
+++ b/vagrantfile
@@ -37,4 +37,5 @@ Vagrant.configure(2) do |config|
     config.vm.provision "update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT}", privileged: true, run: "never"
     config.vm.provision "composer-update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT} update-composer ", privileged: true, run: "never"
     config.vm.provision "full-update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT} full ", privileged: true, run: "never"
+    config.vm.provision "delete-cache", type: "shell", inline: "rm --verbose /var/cache/phplw/*.cache", privileged: true, run: "never"
 end

--- a/vagrantfile
+++ b/vagrantfile
@@ -4,7 +4,7 @@
 REPO_PATH      = "/home/vagrant/github_phplw"
 PROV_SCRIPT    = "vagrant_provision/pl/provision.pl"
 UPDATE_SCRIPT  = "vagrant_provision/pl/update_code.pl"
-PROV_LOG       = ".vagrant/provision.log"
+PROV_LOG       = "logs/provision.log"
 
 Vagrant.require_version ">= 2.2.0"
 


### PR DESCRIPTION
- Update Vagrant provision for file caching.  Cache now uses `/var/cache/phplw/` instead of `/tmp/`.
- New provision: `delete-cache` removes all cache files to be used when the cache goes stale.
- Apache and PHP error logs are now written to repositpry's `logs/` folder.  No files in this folder other than `readme` should be tracked.  This change makes it no longer necessary to SSH into the box to view these Apache/PHP error logs.  Provision log is also now written to `logs/`.
- Provision readme updated.