### PR TITLE
Remove php-gd as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,13 +36,13 @@
 ## Install process
 1. Retrieve required packages for your OS/distribution:
    * Apache2
-   * PHP 7.x, PHP GD Extension
+   * PHP 7.3 or higher
    * MySQL-server, MySQL-client, PHP MySQL Extension
    * You need the Linux Standard Base (LSB) to run Linux-precompiled FlexLM binaries.
 
    For example, using Ubuntu 20.04:
    ```
-   sudo apt install apache2 php php-gd mysql-server mysql-client php-mysql lsb
+   sudo apt install apache2 php mysql-server mysql-client php-mysql lsb
    ```
 2. Clone repostiory locally using git
    ```

--- a/vagrant_provision/pl/provision.pl
+++ b/vagrant_provision/pl/provision.pl
@@ -25,7 +25,7 @@ my @APACHE_PATH = (rootdir(), "etc", "apache2");
 my @CACHE_PATH = (rootdir(), "var", "cache", "phplw");
 
 # Packages needed for phplw.
-my @REQUIRED_PACKAGES = ("apache2", "php", "php-gd", "php-mysql", "mysql-server", "mysql-client", "lsb", "zip", "unzip");
+my @REQUIRED_PACKAGES = ("apache2", "php", "php-mysql", "mysql-server", "mysql-client", "lsb", "zip", "unzip");
 
 # Non super user account.  Some package systems run better when not as root.
 my $NOT_SUPERUSER = "vagrant";

--- a/vagrantfile
+++ b/vagrantfile
@@ -38,7 +38,7 @@ Vagrant.configure(2) do |config|
     config.vm.synced_folder ".", REPO_PATH, create: true, owner: "vagrant", group: "vagrant", mount_options: ['dmode=775', 'fmode=664']
     config.vm.provision "shell", inline: "perl #{REPO_PATH}/#{PROV_SCRIPT} |& tee #{REPO_PATH}/#{PROV_LOG}", privileged: true, run: "once"
     config.vm.provision "update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT}", privileged: true, run: "never"
-    config.vm.provision "composer-update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT} update-composer ", privileged: true, run: "never"
+#   config.vm.provision "composer-update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT} update-composer ", privileged: true, run: "never"
     config.vm.provision "full-update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT} full ", privileged: true, run: "never"
     config.vm.provision "delete-cache", type: "shell", inline: "rm --verbose /var/cache/phplw/*.cache", privileged: true, run: "never"
 end


### PR DESCRIPTION
Updated install docs and vagrant provision that php-gd is no longer a requirement due to graphs being rendered by Google Visualization via javascript.

A couple other minor updates in documentation and vagrant provision.