### PR TITLE
Unix time update

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 
 ## Requirements
 
-* PHP enabled web server
+* 64-bit PHP enabled web server
 * MySQL
 * FlexLM lmstat/lmutil/lmdiag binaries for the OS you are running the web server on.
 

--- a/check_installation.php
+++ b/check_installation.php
@@ -20,6 +20,13 @@ $test_values  = phpversion();
 $test_results = $test ? PASS_MARK : FAIL_MARK;
 $table->add_row(array($test_names, $test_values, $test_results));
 
+// Check for 64-bit Unix timestamp
+$test         = strtotime("9999-12-31") === 253402214400;
+$test_names   = "64-bit Unix Timestamp";
+$test_values  = $test ? "64-bit" : "32-bit";
+$test_results = $test ? PASS_MARK : FAIL_MARK;
+$table->add_row(array($test_names, $test_values, $test_results));
+
 // TO DO: Expand this test to validate config.php values.
 $test         = is_readable("config.php");
 $test_names   = "config.php";

--- a/details.php
+++ b/details.php
@@ -93,9 +93,16 @@ HTML;
                 if ( $dte < 0 ) {
                     $row_attributes['class'] = "already_expired";
                 }
-                $license_msg  = "{$feature_array[$p]['num_licenses']} license(s) expire(s) in ";
-                $license_msg .= "{$feature_array[$p]['days_to_expiration']} day(s) Date of expiration: ";
-                $license_msg .= "{$feature_array[$p]['expiration_date']}";
+
+                if ($feature_array[$p]['expiration_date'] === "permanent") {
+                    $license_msg = "{$feature_array[$p]['num_licenses']} license(s) are permanent.";
+                } else {
+                    $license_msg = <<<MSG
+                    {$feature_array[$p]['num_licenses']} license(s) expire(s) in
+                    {$feature_array[$p]['days_to_expiration']} day(s) Date of expiration:
+                    {$feature_array[$p]['expiration_date']}
+                    MSG;
+                }
             }
         }
 

--- a/details.php
+++ b/details.php
@@ -75,34 +75,27 @@ HTML;
     // their expiration dates etc.
     foreach ($expiration_array as $key => $feature_array) {
         $total_licenses = 0;
-        $dte = 4000;
 
         for ($p = 0; $p < count($feature_array); $p++) {
             // Keep track of total number of licenses for a particular feature
             // this is since you can have licenses with different expiration
             $total_licenses += intval($feature_array[$p]["num_licenses"]);
-
-            // Set row class if license is close to the expiration date.
             $row_attributes = array();
-            if ( $feature_array[$p]["days_to_expiration"] < $dte ) {
+            if ($feature_array[$p]['expiration_date'] === "permanent") {
+                $license_msg = "{$feature_array[$p]['num_licenses']} license(s) are permanent.";
+            } else {
+                // Set row class if license is close to the expiration date.
                 $dte = $feature_array[$p]["days_to_expiration"];
-                if ( $dte <= $lead_time && $dte >= 0 ) {
-                    $row_attributes['class'] = "expires_soon";
+                if ($dte <= $lead_time && $dte >= 0) {
+                    $row_attributes['class'] = "warning"; //bootstrap class
+                } else if ($dte < 0) {
+                    $row_attributes['class'] = "danger"; //bootstrap class
                 }
 
-                if ( $dte < 0 ) {
-                    $row_attributes['class'] = "already_expired";
-                }
-
-                if ($feature_array[$p]['expiration_date'] === "permanent") {
-                    $license_msg = "{$feature_array[$p]['num_licenses']} license(s) are permanent.";
-                } else {
-                    $license_msg = <<<MSG
-                    {$feature_array[$p]['num_licenses']} license(s) expire(s) in
-                    {$feature_array[$p]['days_to_expiration']} day(s) Date of expiration:
-                    {$feature_array[$p]['expiration_date']}
-                    MSG;
-                }
+                $license_msg = <<<MSG
+                {$feature_array[$p]['num_licenses']} license(s) expire(s) in {$feature_array[$p]['days_to_expiration']} day(s).
+                Date of expiration: {$feature_array[$p]['expiration_date']}
+                MSG;
             }
         }
 

--- a/tools.php
+++ b/tools.php
@@ -7,42 +7,68 @@
 function build_license_expiration_array($server, &$expiration_array) {
     global $lmutil_binary; // from config.php
 
-    $total_licenses = 0;
     $file = popen("{$lmutil_binary} lmcksum -c {$server}", "r");
     $today = time();
+    // Expirations (in days) longer than 10 years are assumed permanent.
+    $permanent_threshold = 4000; // Nice round number greater than 10 years (in days)
 
     // Let's read in the file line by line
     while (!feof ($file)) {
         $line = fgets ($file, 1024);
         if ( preg_match("/INCREMENT .*/i", $line, $out ) || preg_match("/FEATURE .*/i", $line, $out ) ) {
             $license = explode(" ", $out[0]);
-            $days_to_expiration = 4001;  # > 4000;
-            if ( $license[4] )  {
-                // UNIX time stamps go only till year 2038 (or so) so convert
-                // any license dates 9999 or 0000 (which means infinity) to
-                // an acceptable year. 2036 seems like a good number
+            // $days_to_expiration = 4001;  # > 4000;
+            if ($license[4]) {
                 $license[4] = strtolower($license[4]);
-                $license[4] = str_replace("-9999", "-2036", $license[4]);
-                $license[4] = str_replace("-0000", "-2036", $license[4]);
-                $license[4] = str_replace("-2099", "-2036", $license[4]);
-                $license[4] = str_replace("-2242", "-2036", $license[4]);
-                $license[4] = str_replace("-jan-00", "-jan-2036", $license[4]);
-                $license[4] = str_replace("-jan-0", "-jan-2036", $license[4]);
-                $license[4] = str_replace("-0", "-2036", $license[4]);
-                $license[4] = str_replace("permanent", "05-jul-2036", $license[4]);
-                $unixdate2 = strtotime($license[4]);
-
-                // Convert the date you got into UNIX time
-                $unixdate2 = strtotime($license[4]);
-                $dte = ceil ((1 + $unixdate2 - $today) / 86400);
-                $days_to_expiration = $dte;
-            }
-            // If there is more than 4000 days (10 years+) until expiration, I
-            // will consider the license to be permanent
-            if ( $days_to_expiration > 4000 ) {
+                switch(true) {
+                // Indicators that license is perpetual/permanent
+                case preg_match("/-0000$/", license[4]) === 1:
+                case preg_match("/-9999$/", license[4]) === 1:
+                case preg_match("/-2099$/", license[4]) === 1:
+                case preg_match("/-2242$/", license[4]) === 1:
+                case preg_match("/-00$/", license[4]) === 1:
+                case preg_match("/-0$/", license[4]) === 1:
+                case $license[4] === "permanent":
+                    $days_to_expiration = 0;
+                    $license[4] = "permanent";
+                    break;
+                // License not indicated as permanent.  Calculate days remaining.
+                // We are assuming 64-bit Unix time.
+                default:
+                    $days_to_expiration = ceil((1 + strtotime($license[4]) - $today) / 86400);
+                    if ($days_to_expiration > $permanent_threshold) {
+                        $days_to_expiration = 0;
+                        $license[4] = "permanent";
+                    }
+                    break;
+                }
+            } else {
+                // We didn't find an expiration date, so assume license is permanent.
+                $days_to_expiration = 0;
                 $license[4] = "permanent";
-                // $days_to_expiration = "permanent";
             }
+
+            //     $license[4] = str_replace("-9999", "-2036", $license[4]);
+            //     $license[4] = str_replace("-0000", "-2036", $license[4]);
+            //     $license[4] = str_replace("-2099", "-2036", $license[4]);
+            //     $license[4] = str_replace("-2242", "-2036", $license[4]);
+            //     $license[4] = str_replace("-jan-00", "-jan-2036", $license[4]);
+            //     $license[4] = str_replace("-jan-0", "-jan-2036", $license[4]);
+            //     $license[4] = str_replace("-0", "-2036", $license[4]);
+            //     $license[4] = str_replace("permanent", "05-jul-2036", $license[4]);
+            //     $unixdate2 = strtotime($license[4]);
+            //
+            //     // Convert the date you got into UNIX time
+            //     $unixdate2 = strtotime($license[4]);
+            //     $dte = ceil ((1 + $unixdate2 - $today) / 86400);
+            //     $days_to_expiration = $dte;
+            // }
+            // // If there is more than 4000 days (10 years+) until expiration, I
+            // // will consider the license to be permanent
+            // if ( $days_to_expiration > 4000 ) {
+            //     $license[4] = "permanent";
+            //     // $days_to_expiration = "permanent";
+            // }
 
             // Add to the expiration array
             $expiration_array[$license[1]][] = array (

--- a/tools.php
+++ b/tools.php
@@ -22,12 +22,12 @@ function build_license_expiration_array($server, &$expiration_array) {
                 $license[4] = strtolower($license[4]);
                 switch(true) {
                 // Indicators that license is perpetual/permanent
-                case preg_match("/-0000$/", license[4]) === 1:
-                case preg_match("/-9999$/", license[4]) === 1:
-                case preg_match("/-2099$/", license[4]) === 1:
-                case preg_match("/-2242$/", license[4]) === 1:
-                case preg_match("/-00$/", license[4]) === 1:
-                case preg_match("/-0$/", license[4]) === 1:
+                case preg_match("/-0000$/", $license[4]) === 1:
+                case preg_match("/-9999$/", $license[4]) === 1:
+                case preg_match("/-2099$/", $license[4]) === 1:
+                case preg_match("/-2242$/", $license[4]) === 1:
+                case preg_match("/-00$/", $license[4]) === 1:
+                case preg_match("/-0$/", $license[4]) === 1:
                 case $license[4] === "permanent":
                     $days_to_expiration = 0;
                     $license[4] = "permanent";


### PR DESCRIPTION
Close #68 
- Use 64-bit Unix time.
- No longer using artificial deltas to calculate license expiration time (as a consequence of 32-bit unix time)
- Update docs and check_installation for 64-bit unix time requirement.  (64-bit Linux has got to be quite common by now).
    - Tested: 64-bit unix time is also supported in php under macos catalina and win10.
- Bugfix for class properties for expiring licenses.
    - Expiring licenses within 30 days have yellow background.
    - Expired licenses have a red background.