### PR TITLE
Vagrant Update

### DIFF
--- a/vagrant_provision/README.md
+++ b/vagrant_provision/README.md
@@ -66,6 +66,7 @@ You may develop code for this repository on your host.  Make sure the VM is runn
 * If you are getting a "connection was reset" error in your web browser, Apache may not be running.
     1. Enter the Vagrant box via ssh. `vagrant ssh`
     2. Start Apache. `sudo apachectl start` or `sudo apachectl restart`
+* Should `vagrant ssh` fail to authenticate, you can alternatively try `ssh -p 2222 vagrant@localhost`.  Password is `vagrant`.
 
 ### Common Commands
 Command | Purpose

--- a/vagrantfile
+++ b/vagrantfile
@@ -20,7 +20,7 @@ Vagrant.configure(2) do |config|
         # Resync the clock if it drifts by more than 10 seconds.  Useful for when host wakes up from sleep.
         virtualbox.customize ['guestproperty', 'set', :id, '/VirtualBox/GuestAdd/VBoxService/--timesync-set-threshold', 10000]
         # Helps work around DNS problems that may happen with large campus LANs or VPN.
-        virtualbox.customize ['modifyvm', :id, '--natdnsproxy1', 'on']
+        virtualbox.customize ['modifyvm', :id, '--natdnshostresolver1', 'on']
     end
 
     config.vm.define "dev_box", primary: true do |phplw|


### PR DESCRIPTION
- switch to `natdnsresolver1` to use host's DNS.
- How to gain ssh access when `vagrant ssh` fails.