### PR TITLE
Add history graph links and other fixes

### DIFF
--- a/check_installation.php
+++ b/check_installation.php
@@ -21,7 +21,7 @@ $test_results = $test ? PASS_MARK : FAIL_MARK;
 $table->add_row(array($test_names, $test_values, $test_results));
 
 // Check for 64-bit Unix timestamp
-$test         = strtotime("9999-12-31") === 253402214400;
+$test         = strtotime("9999-12-31") !== false;
 $test_names   = "64-bit Unix Timestamp";
 $test_values  = $test ? "64-bit" : "32-bit";
 $test_results = $test ? PASS_MARK : FAIL_MARK;

--- a/common.php
+++ b/common.php
@@ -180,7 +180,6 @@ function get_not_polled_notice() {
 function ajax_send_data($data, $mime='plain/text') {
     header("Content-Type: {$mime}");
     print $data;
-    log_var($data, 3);
 } // END function ajax_send_data()
 
 /**
@@ -211,6 +210,15 @@ function print_var ($var) {
     }
 }
 
+/**
+ * Debug helper function to send var_export() to a file.
+ *
+ * The files are written to /home/vagrant and should be something like
+ * "var0.txt", "var1.txt", etc.  If the files aren't being written, it is
+ * likely a permissions issue.  $ chmod ugo+w /home/vagrant
+ *
+ * @param mixed $var variable to be exported to browser view.
+ */
 function log_var($var, $num=0) {
     global $debug; // from config.php
     if (isset($debug) && $debug == 1) {

--- a/details.php
+++ b/details.php
@@ -178,6 +178,10 @@ HTML;
 
             $line = fgets($fp);
         }
+        
+        uasort($used_licenses, function($a, $b) {
+            return strcasecmp($a['feature_name'], $b['feature_name']);
+        });
 
         $unused_licenses = array_udiff(get_features_and_licenses($server['id']), $used_licenses, function($a, $b) {
             return $a['feature_name'] <=> $b['feature_name'];
@@ -279,6 +283,7 @@ function get_features_and_licenses($server_id) {
     JOIN `licenses` ON `available`.`license_id` = `licenses`.`feature_id`
     JOIN `features` ON `licenses`.`feature_id` = `features`.`id`
     WHERE `licenses`.`server_id` = ?
+    ORDER BY `features`.`name`
     SQL;
 
     $params = array('i', $server_id);

--- a/details.php
+++ b/details.php
@@ -178,7 +178,7 @@ HTML;
 
             $line = fgets($fp);
         }
-        
+
         uasort($used_licenses, function($a, $b) {
             return strcasecmp($a['feature_name'], $b['feature_name']);
         });
@@ -282,7 +282,7 @@ function get_features_and_licenses($server_id) {
     SELECT `features`.`name`, `available`.`num_licenses` FROM `available`
     JOIN `licenses` ON `available`.`license_id` = `licenses`.`feature_id`
     JOIN `features` ON `licenses`.`feature_id` = `features`.`id`
-    WHERE `licenses`.`server_id` = ?
+    WHERE `licenses`.`server_id` = ? AND `features`.`show_in_lists` = 1
     ORDER BY `features`.`name`
     SQL;
 

--- a/details.php
+++ b/details.php
@@ -119,7 +119,6 @@ function list_licenses_in_use($servers, &$html_body) {
     $html_body .= <<<HTML
 <p>Following is the list of licenses currently being used.
 Licenses that are currently not in use are not shown.</p>
-
 HTML;
 
     // If person is filtering for certain features
@@ -136,12 +135,13 @@ HTML;
 
     // Loop through the available servers
     foreach ($servers as $server) {
+        // Get features
+        $licenses = get_features_and_licenses($server['id']);
+
         // Execute lmutil lmstat -A -c port@server_fqdn
+        // switch -A reports only licenses in use.
         $fp = popen("{$lmutil_binary} lmstat -A -c {$server['name']}", "r");
-        $line = fgets($fp, 1024);
-
-
-        $no_licenses_in_use_warning = true;
+        $line = fgets($fp);
 
         // Loop through the output. Look for lines starting with Users. Then look for any
         // consecutive entries showing who is using it
@@ -149,174 +149,139 @@ HTML;
             // Look for features in a $line.  Example $line:
             // Users of Allegro_Viewer:  (Total of 5 licenses issued;  Total of 2 licenses in use)
             switch (1) {
-            case preg_match('/^Users of ([\w\- ]+):  \(Total of (\d+) licenses issued;  Total of (\d+)/i', $line, $matches):
-                $feature            = $matches[1];
-                $num_licenses       = $matches[2];
-                $num_licenses_used  = $matches[3];
-                $user = array(); // $user, $host, $date, $time are parallel arrays
-                $host = array();
-                $date = array();
-                $time = array();
-                $no_licenses_in_use_warning = false;
-                $license_checkout_regex = "/^([^ ]+) ([^ ]+) .+ ([0-9]{1,2}\/[0-9]{1,2}) ([0-9]{1,2}:[0-9]{2})/i";
-                $line = fgets($fp, 1024);
+            case preg_match('/^Users of ([\w\- ]+):  \(Total of (\d+) licenses* issued;  Total of (\d+)/i', $line, $matches):
+                $feature_name = $matches[1];
+                $licenses[$feature_name]['num_licenses'] = $matches[2];
+                $licenses[$feature_name]['licenses_used'] = $matches[3];
 
-                while(preg_match($license_checkout_regex, $line, $matches)) {
-                    $user[] = $match[1];
-                    $host[] = $match[2];
-                    $date[] = $match[3];
-                    $time[] = $match[4];
-                    $line = fgets($fp, 1024);
+                $licenses_used = (int) $matches[3];
+                $i = 0;
+                while ($i < $licenses_used) {
+                    $line = fgets($fp);
+                    if (preg_match("/^([^ ]+) ([^ ]+) .+ ([0-9]{1,2}\/[0-9]{1,2}) ([0-9]{1,2}:[0-9]{2})/i", $line, $matches)) {
+                        $licenses[$feature_name]['licenses_used'][$i]['user'] = $matches[1];
+                        $licenses[$feature_name]['licenses_used'][$i]['host'] = $matches[2];
+                        $licenses[$feature_name]['licenses_used'][$i]['date'] = $matches[3];
+                        $licenses[$feature_name]['licenses_used'][$i]['time'] = $matches[4];
+                        $i++;
+                    }
                 }
                 break;
-            case preg_match('/^Users of ([\w\- ]+):  \(Uncounted, node-locked/i', $line, $matches):
-                $feature           = $matches[1];
-                $num_licenses      = "uncounted";
-                $num_licenses_used = "uncounted";
-                $user = array(); // $user, $host, $date, $time are parallel arrays
-                $host = array(); // They need to be emptied/reset.
-                $date = array();
-                $time = array();
+            case preg_match('/^Users of ([\w\- ]+):  \(Uncounted/i', $line, $matches):
+                $i++;
+                $feature_name = $matches[1];
+                $licenses[$feature_name]['num_licenses'] = "uncounted";
+                $licenses[$feature_name]['licenses_used'] = "uncounted";
                 break;
             }
+
+            $line = fgets($fp);
         }
 
-        $log[]['feature'] = $feature;
-        $log[]['num_licenses'] = $num_licenses;
-        $log[]['num_licenses_used'] = $num_licenses_used;
-        $key = array_key_last($user);
-        if (is_int($key)) {
-            $log[]['user'] = $user[$key];
-            $log[]['host'] = $host[$key];
-            $log[]['date'] = $host[$key];
-            $log[]['time'] = $host[$key];
+        var_log($licenses,0);die;
+
+        // Check whether anyone is using licenses from this particular license server
+        if ( $i > -1 ) {
+            // Create a new table
+            $table = new html_table(array('class'=>"table"));
+
+            // Show a banner with the name of the serve@port plus description
+            $colHeaders = array("Server: {$server['name']} ({$server['label']})");
+            $table->add_row($colHeaders, array(), "th");
+            $table->update_cell(0, 0, array('colspan'=>"4"));
+
+            $colHeaders = array("Feature", "# Cur. Avail", "Details", "Time Checked Out");
+            $table->add_row($colHeaders, array(), "th");
+
+            // Get current UNIX time stamp
+            $now = time();
+
+            // Loop through the used features
+            for ( $j = 0 ; $j <= $i ; $j++ ) {
+                if ( ! isset($_GET['filter_feature']) || in_array($licenses[$j]['feature'], $_GET['filter_feature']) ) {
+                    $feature = $licenses[$j]['feature'] ;
+                    $graph_url = "monitor_detail.php?feature={$feature}";
+
+                    // How many licenses are currently used
+                    $licenses_available = $licenses[$j]['num_licenses'] - $licenses[$j]['licenses_used'];
+                    $license_info = "Total of {$licenses[$j]['num_licenses']} licenses, ";
+                    $license_info .= "{$licenses[$j]['licenses_used']} currently in use, ";
+                    $license_info .= "<span style='font-weight: bold'>{$licenses_available} available</span>";
+                    $license_info .= "<br/><a href='{$graph_url}'>Historical Usage</a>";
+                    $class = $j%2===0 ? array('class'=>"alt-bgcolor") : array();
+                    $table->add_row(array($licenses[$j]['feature'], $licenses_available, $license_info, ""), $class);
+
+                    // Not all used features have checkout-time data.  Skip over those that don't.
+                    if (isset($used_licenses[$server['name']][$j]) && is_countable($used_licenses[$server['name']][$j])) {
+                        foreach ($used_licenses[$server['name']][$j] as $used_license) {
+                            /* ---------------------------------------------------------------------------
+                             * I want to know how long a license has been checked out. This
+                             * helps in case some people forgot to close an application and
+                             * have licenses checked out for too long.
+                             * LMstat view will contain a line that says
+                             * jdoe machine1 /dev/pts/4 (v4.0) (licenserver/27000 444), start Thu 12/5 9:57
+                             * the date after start is when license was checked out
+                             * ---------------------------------------------------------------------------- */
+                            $line = explode(", start ", $used_license);
+                            preg_match("/(.+?) (.+?) (\d+):(\d+)/i", $line[1], $line2);
+
+                            // Convert the date and time ie 12/5 9:57 to UNIX time stamp
+                            $time_checkedout = strtotime ($line2[2] . " " . $line2[3] . ":" . $line2[4]);
+                            $time_difference = "";
+
+                            /* ---------------------------------------------------------------------------
+                             * This is what I am not very clear on but let's say a license has been
+                             * checked out on 12/31 and today is 1/2. It is unclear to me whether
+                             * strotime will handle the conversion correctly ie. 12/31 will actually
+                             * be 12/31 of previous year and not the current. Thus I will make a
+                             * little check here. Will just append the previous year if now is less
+                             * then time_checked_out
+                             * ---------------------------------------------------------------------------- */
+                            if ( $now < $time_checkedout ) {
+                                $time_checkedout = strtotime ($line2[2] . "/" . (date("Y") - 1) . " " . $line2[3]);
+                            } else {
+                                // Get the time difference
+                                $t = new timespan( $now, $time_checkedout );
+
+                                // Format the date string
+                                if ( $t->years > 0) $time_difference .= $t->years . " years(s), ";
+                                if ( $t->months > 0) $time_difference .= $t->months . " month(s), ";
+                                if ( $t->weeks > 0) $time_difference .= $t->weeks . " week(s), ";
+                                if ( $t->days > 0) $time_difference .= " " . $t->days . " day(s), ";
+                                if ( $t->hours > 0) $time_difference .= " " . $t->hours . " hour(s), ";
+                                $time_difference .= $t->minutes . " minute(s)";
+                            }
+
+                            // Output the user line
+                            $user_line = $used_license;
+                            $user_line_parts = explode( ' ', trim($user_line) );
+                            $user_line_formated = "<span>User: ".$user_line_parts[0]."</span> ";
+                            $user_line_formated .= "<span>Computer: ".$user_line_parts[2]."</span> ";
+                            $table->add_row(array("", "", $user_line_formated, $time_difference), $class);
+                        }
+                    }
+                }
+            }
+
+            // Display the table
+            if ($table->get_rows_count() > 2 ) {
+                $html_body .= $table->get_html();
+            }
+
+        } else {
+            // color #dc143c is "crimson", which is better than "red" for contrast ratio against white background.
+            $html_body .= "<p style='color: #dc143c;'>No licenses are currently being used on {$server['name']} ({$server['label']})</p>";
         }
-        set_time_limit(30);
+        pclose($fp);
     } // END foreach ($servers as $server)
-    log_var($log, 0);
 } // END function list_licenses_for_use()
 
-
-
-            // Next: build HTML data row
-            // -------------------------
-
-
-        //     if ( preg_match("/, start/i", $line ) ){
-        //         $used_licenses[$server['name']][$i][] = $line;
-        //     }
-        // }
-        //
-        // // Check whether anyone is using licenses from this particular license server
-        // if ( $i > -1 ) {
-        //     // Create a new table
-        //     $table = new html_table(array('class'=>"table"));
-        //
-        //     // Show a banner with the name of the serve@port plus description
-        //     $colHeaders = array("Server: {$server['name']} ({$server['label']})");
-        //     $table->add_row($colHeaders, array(), "th");
-        //     $table->update_cell(0, 0, array('colspan'=>"4"));
-        //
-        //     $colHeaders = array("Feature", "# Cur. Avail", "Details", "Time Checked Out");
-        //     $table->add_row($colHeaders, array(), "th");
-        //
-        //     // Get current UNIX time stamp
-        //     $now = time();
-        //
-        //     // Loop through the used features
-        //     for ( $j = 0 ; $j <= $i ; $j++ ) {
-        //         if ( ! isset($_GET['filter_feature']) || in_array($licenses[$j]['feature'], $_GET['filter_feature']) ) {
-        //             $feature = $licenses[$j]['feature'] ;
-        //             $graph_url = "monitor_detail.php?feature={$feature}";
-        //
-        //             // How many licenses are currently used
-        //             $licenses_available = $licenses[$j]['num_licenses'] - $licenses[$j]['licenses_used'];
-        //             $license_info = "Total of {$licenses[$j]['num_licenses']} licenses, ";
-        //             $license_info .= "{$licenses[$j]['licenses_used']} currently in use, ";
-        //             $license_info .= "<span style='font-weight: bold'>{$licenses_available} available</span>";
-        //             $license_info .= "<br/><a href='{$graph_url}'>Historical Usage</a>";
-        //             $class = $j%2===0 ? array('class'=>"alt-bgcolor") : array();
-        //             $table->add_row(array($licenses[$j]['feature'], $licenses_available, $license_info, ""), $class);
-        //
-        //             // Not all used features have checkout-time data.  Skip over those that don't.
-        //             if (isset($used_licenses[$server['name']][$j]) && is_countable($used_licenses[$server['name']][$j])) {
-        //                 foreach ($used_licenses[$server['name']][$j] as $used_license) {
-        //                     /* ---------------------------------------------------------------------------
-        //                      * I want to know how long a license has been checked out. This
-        //                      * helps in case some people forgot to close an application and
-        //                      * have licenses checked out for too long.
-        //                      * LMstat view will contain a line that says
-        //                      * jdoe machine1 /dev/pts/4 (v4.0) (licenserver/27000 444), start Thu 12/5 9:57
-        //                      * the date after start is when license was checked out
-        //                      * ---------------------------------------------------------------------------- */
-        //                     $line = explode(", start ", $used_license);
-        //                     preg_match("/(.+?) (.+?) (\d+):(\d+)/i", $line[1], $line2);
-        //
-        //                     // Convert the date and time ie 12/5 9:57 to UNIX time stamp
-        //                     $time_checkedout = strtotime ($line2[2] . " " . $line2[3] . ":" . $line2[4]);
-        //                     $time_difference = "";
-        //
-        //                     /* ---------------------------------------------------------------------------
-        //                      * This is what I am not very clear on but let's say a license has been
-        //                      * checked out on 12/31 and today is 1/2. It is unclear to me whether
-        //                      * strotime will handle the conversion correctly ie. 12/31 will actually
-        //                      * be 12/31 of previous year and not the current. Thus I will make a
-        //                      * little check here. Will just append the previous year if now is less
-        //                      * then time_checked_out
-        //                      * ---------------------------------------------------------------------------- */
-        //                     if ( $now < $time_checkedout ) {
-        //                         $time_checkedout = strtotime ($line2[2] . "/" . (date("Y") - 1) . " " . $line2[3]);
-        //                     } else {
-        //                         // Get the time difference
-        //                         $t = new timespan( $now, $time_checkedout );
-        //
-        //                         // Format the date string
-        //                         if ( $t->years > 0) $time_difference .= $t->years . " years(s), ";
-        //                         if ( $t->months > 0) $time_difference .= $t->months . " month(s), ";
-        //                         if ( $t->weeks > 0) $time_difference .= $t->weeks . " week(s), ";
-        //                         if ( $t->days > 0) $time_difference .= " " . $t->days . " day(s), ";
-        //                         if ( $t->hours > 0) $time_difference .= " " . $t->hours . " hour(s), ";
-        //                         $time_difference .= $t->minutes . " minute(s)";
-        //                     }
-        //
-        //                     // Output the user line
-        //                     $user_line = $used_license;
-        //                     $user_line_parts = explode( ' ', trim($user_line) );
-        //                     $user_line_formated = "<span>User: ".$user_line_parts[0]."</span> ";
-        //                     $user_line_formated .= "<span>Computer: ".$user_line_parts[2]."</span> ";
-        //                     $table->add_row(array("", "", $user_line_formated, $time_difference), $class);
-        //                 }
-        //             }
-        //         }
-        //     }
-        //
-        //     // Display the table
-        //     if ($table->get_rows_count() > 2 ) {
-        //         $html_body .= $table->get_html();
-        //     }
-        //
-        // } else {
-        //     $features = get_features_list($server['id']);
-        //     $table = new html_table(array('class'=>"table alt-rows-bgcolor"));
-        //     $table->add_row(array("Historical Usage"), null, "th");
-        //     foreach($features as $feature) {
-        //         $link = "<a href='monitor_detail.php?feature={$feature}'>{$feature}</a>";
-        //         $table->add_row(array($link));
-        //     }
-        //
-        //     // color #dc143c is "crimson", which is better than "red" for contrast ratio against white background.
-        //     $html_body .= "<p style='color: #dc143c;'>No licenses are currently being used on {$server['name']} ({$server['label']})</p>";
-        //     $html_body .= $table->get_html();
-        // }
-        // pclose($fp);
-//     } // END foreach ($servers as $server)
-// } // END function list_licenses_for_use()
-
-function get_features_list($server_id) {
+function get_features_and_licenses($server_id) {
     $sql = <<<SQL
-    SELECT `name` FROM `features`
-    JOIN `licenses` ON `features`.`id` = `licenses`.`feature_id`
-    WHERE `licenses`.`server_id`=?
+    SELECT `features`.`name`, `available`.`num_licenses` FROM `available`
+    JOIN `licenses` ON `available`.`license_id` = `licenses`.`feature_id`
+    JOIN `features` ON `licenses`.`feature_id` = `features`.`id`
+    WHERE `licenses`.`server_id` = ?
     SQL;
 
     $params = array('i', $server_id);
@@ -326,9 +291,9 @@ function get_features_list($server_id) {
     $query = $db->prepare($sql);
     $query->bind_param(...$params);
     $query->execute();
-    $query->bind_result($feature_name);
+    $query->bind_result($feature_name, $num_licenses);
     while ($query->fetch()) {
-        $results[] = $feature_name;
+        $results[$feature_name]['num_licenses'] = $num_licenses;
     }
 
     if (!empty($db->error_list)) {

--- a/details.php
+++ b/details.php
@@ -131,146 +131,146 @@ HTML;
         $html_body .= ("</span></p>");
     }
 
-    $licenses = array();
-
     // Loop through the available servers
     foreach ($servers as $server) {
-        // Get features
-        $licenses = get_features_and_licenses($server['id']);
-
         // Execute lmutil lmstat -A -c port@server_fqdn
         // switch -A reports only licenses in use.
         $fp = popen("{$lmutil_binary} lmstat -A -c {$server['name']}", "r");
         $line = fgets($fp);
 
-        // Loop through the output. Look for lines starting with Users. Then look for any
-        // consecutive entries showing who is using it
+        $no_licenses_in_use_warning = true;
+        $used_licenses = array();
+        $i = 0;
+
+        // Loop through the output. Look for lines starting with Users.
+        // Then look for any consecutive entries showing who is using it.
         while (!feof($fp)) {
             // Look for features in a $line.  Example $line:
             // Users of Allegro_Viewer:  (Total of 5 licenses issued;  Total of 2 licenses in use)
             switch (1) {
-            case preg_match('/^Users of ([\w\- ]+):  \(Total of (\d+) licenses* issued;  Total of (\d+)/i', $line, $matches):
-                $feature_name = $matches[1];
-                $licenses[$feature_name]['num_licenses'] = $matches[2];
-                $licenses[$feature_name]['licenses_used'] = $matches[3];
+            case preg_match('/^Users of ([\w\- ]+):  \(Total of (\d+) licenses? issued;  Total of (\d+)/i', $line, $matches):
+                $used_licenses[$i]['feature_name'] = $matches[1];
+                $used_licenses[$i]['num_licenses'] = $matches[2];
+                $used_licenses[$i]['num_licenses_used'] = $matches[3];
+                $num_licenses_used = (int) $matches[3];
 
-                $licenses_used = (int) $matches[3];
-                $i = 0;
-                while ($i < $licenses_used) {
+                $no_licenses_in_use_warning = false;
+                $j = 0;
+                while ($j < $num_licenses_used && !feof($fp)) {
                     $line = fgets($fp);
-                    if (preg_match("/^([^ ]+) ([^ ]+) .+ ([0-9]{1,2}\/[0-9]{1,2}) ([0-9]{1,2}:[0-9]{2})/i", $line, $matches)) {
-                        $licenses[$feature_name]['licenses_used'][$i]['user'] = $matches[1];
-                        $licenses[$feature_name]['licenses_used'][$i]['host'] = $matches[2];
-                        $licenses[$feature_name]['licenses_used'][$i]['date'] = $matches[3];
-                        $licenses[$feature_name]['licenses_used'][$i]['time'] = $matches[4];
-                        $i++;
+                    if (preg_match("/^ *([^ ]+) ([^ ]+) .+, start \w{3} ([0-9]{1,2}\/[0-9]{1,2}) ([0-9]{1,2}:[0-9]{2})/i", $line, $matches) === 1) {
+                        $used_licenses[$i]['checkouts'][$j]['user'] = $matches[1];
+                        $used_licenses[$i]['checkouts'][$j]['host'] = $matches[2];
+                        $used_licenses[$i]['checkouts'][$j]['date'] = $matches[3];
+                        $used_licenses[$i]['checkouts'][$j]['time'] = $matches[4];
+                        $j++;
                     }
                 }
+                $i++;
                 break;
             case preg_match('/^Users of ([\w\- ]+):  \(Uncounted/i', $line, $matches):
+                $used_licenses[$i]['feature_name'] = $matches[1];
+                $used_licenses[$i]['num_licenses'] = "uncounted";
+                $used_licenses[$i]['num_licenses_used'] = "uncounted";
                 $i++;
-                $feature_name = $matches[1];
-                $licenses[$feature_name]['num_licenses'] = "uncounted";
-                $licenses[$feature_name]['licenses_used'] = "uncounted";
                 break;
             }
 
             $line = fgets($fp);
         }
 
-        var_log($licenses,0);die;
+        $unused_licenses = array_udiff(get_features_and_licenses($server['id']), $used_licenses, function($a, $b) {
+            return $a['feature_name'] <=> $b['feature_name'];
+        });
 
-        // Check whether anyone is using licenses from this particular license server
-        if ( $i > -1 ) {
-            // Create a new table
-            $table = new html_table(array('class'=>"table"));
+        if ($no_licenses_in_use_warning) {
+            $html_body .= get_alert_html("No licenses are currently being used on {$server['name']} ({$server['label']})", "info");
+        }
 
-            // Show a banner with the name of the serve@port plus description
-            $colHeaders = array("Server: {$server['name']} ({$server['label']})");
-            $table->add_row($colHeaders, array(), "th");
-            $table->update_cell(0, 0, array('colspan'=>"4"));
+        // Create a new table
+        $table = new html_table(array('class'=>"table"));
 
-            $colHeaders = array("Feature", "# Cur. Avail", "Details", "Time Checked Out");
-            $table->add_row($colHeaders, array(), "th");
+        // Show a banner with the name of the serve@port plus description
+        $colHeaders = array("Server: {$server['name']} ({$server['label']})");
+        $table->add_row($colHeaders, array(), "th");
+        $table->update_cell(0, 0, array('colspan'=>"4"));
 
-            // Get current UNIX time stamp
-            $now = time();
+        $colHeaders = array("Feature", "# Cur. Avail", "Details", "Time Checked Out");
+        $table->add_row($colHeaders, array(), "th");
 
-            // Loop through the used features
-            for ( $j = 0 ; $j <= $i ; $j++ ) {
-                if ( ! isset($_GET['filter_feature']) || in_array($licenses[$j]['feature'], $_GET['filter_feature']) ) {
-                    $feature = $licenses[$j]['feature'] ;
-                    $graph_url = "monitor_detail.php?feature={$feature}";
+        // Get current UNIX time stamp
+        $now = time();
 
-                    // How many licenses are currently used
-                    $licenses_available = $licenses[$j]['num_licenses'] - $licenses[$j]['licenses_used'];
-                    $license_info = "Total of {$licenses[$j]['num_licenses']} licenses, ";
-                    $license_info .= "{$licenses[$j]['licenses_used']} currently in use, ";
-                    $license_info .= "<span style='font-weight: bold'>{$licenses_available} available</span>";
-                    $license_info .= "<br/><a href='{$graph_url}'>Historical Usage</a>";
-                    $class = $j%2===0 ? array('class'=>"alt-bgcolor") : array();
-                    $table->add_row(array($licenses[$j]['feature'], $licenses_available, $license_info, ""), $class);
+        // Loop through the used features
+        for ( $j = 0 ; $j <= $i ; $j++ ) {
+            if ( ! isset($_GET['filter_feature']) || in_array($licenses[$j]['feature'], $_GET['filter_feature']) ) {
+                $feature = $licenses[$j]['feature'] ;
+                $graph_url = "monitor_detail.php?feature={$feature}";
 
-                    // Not all used features have checkout-time data.  Skip over those that don't.
-                    if (isset($used_licenses[$server['name']][$j]) && is_countable($used_licenses[$server['name']][$j])) {
-                        foreach ($used_licenses[$server['name']][$j] as $used_license) {
-                            /* ---------------------------------------------------------------------------
-                             * I want to know how long a license has been checked out. This
-                             * helps in case some people forgot to close an application and
-                             * have licenses checked out for too long.
-                             * LMstat view will contain a line that says
-                             * jdoe machine1 /dev/pts/4 (v4.0) (licenserver/27000 444), start Thu 12/5 9:57
-                             * the date after start is when license was checked out
-                             * ---------------------------------------------------------------------------- */
-                            $line = explode(", start ", $used_license);
-                            preg_match("/(.+?) (.+?) (\d+):(\d+)/i", $line[1], $line2);
+                // How many licenses are currently used
+                $licenses_available = $licenses[$j]['num_licenses'] - $licenses[$j]['licenses_used'];
+                $license_info = "Total of {$licenses[$j]['num_licenses']} licenses, ";
+                $license_info .= "{$licenses[$j]['licenses_used']} currently in use, ";
+                $license_info .= "<span style='font-weight: bold'>{$licenses_available} available</span>";
+                $license_info .= "<br/><a href='{$graph_url}'>Historical Usage</a>";
+                $class = $j%2===0 ? array('class'=>"alt-bgcolor") : array();
+                $table->add_row(array($licenses[$j]['feature'], $licenses_available, $license_info, ""), $class);
 
-                            // Convert the date and time ie 12/5 9:57 to UNIX time stamp
-                            $time_checkedout = strtotime ($line2[2] . " " . $line2[3] . ":" . $line2[4]);
-                            $time_difference = "";
+                // Not all used features have checkout-time data.  Skip over those that don't.
+                if (isset($used_licenses[$server['name']][$j]) && is_countable($used_licenses[$server['name']][$j])) {
+                    foreach ($used_licenses[$server['name']][$j] as $used_license) {
+                        /* ---------------------------------------------------------------------------
+                         * I want to know how long a license has been checked out. This
+                         * helps in case some people forgot to close an application and
+                         * have licenses checked out for too long.
+                         * LMstat view will contain a line that says
+                         * jdoe machine1 /dev/pts/4 (v4.0) (licenserver/27000 444), start Thu 12/5 9:57
+                         * the date after start is when license was checked out
+                         * ---------------------------------------------------------------------------- */
+                        $line = explode(", start ", $used_license);
+                        preg_match("/(.+?) (.+?) (\d+):(\d+)/i", $line[1], $line2);
 
-                            /* ---------------------------------------------------------------------------
-                             * This is what I am not very clear on but let's say a license has been
-                             * checked out on 12/31 and today is 1/2. It is unclear to me whether
-                             * strotime will handle the conversion correctly ie. 12/31 will actually
-                             * be 12/31 of previous year and not the current. Thus I will make a
-                             * little check here. Will just append the previous year if now is less
-                             * then time_checked_out
-                             * ---------------------------------------------------------------------------- */
-                            if ( $now < $time_checkedout ) {
-                                $time_checkedout = strtotime ($line2[2] . "/" . (date("Y") - 1) . " " . $line2[3]);
-                            } else {
-                                // Get the time difference
-                                $t = new timespan( $now, $time_checkedout );
+                        // Convert the date and time ie 12/5 9:57 to UNIX time stamp
+                        $time_checkedout = strtotime ($line2[2] . " " . $line2[3] . ":" . $line2[4]);
+                        $time_difference = "";
 
-                                // Format the date string
-                                if ( $t->years > 0) $time_difference .= $t->years . " years(s), ";
-                                if ( $t->months > 0) $time_difference .= $t->months . " month(s), ";
-                                if ( $t->weeks > 0) $time_difference .= $t->weeks . " week(s), ";
-                                if ( $t->days > 0) $time_difference .= " " . $t->days . " day(s), ";
-                                if ( $t->hours > 0) $time_difference .= " " . $t->hours . " hour(s), ";
-                                $time_difference .= $t->minutes . " minute(s)";
-                            }
+                        /* ---------------------------------------------------------------------------
+                         * This is what I am not very clear on but let's say a license has been
+                         * checked out on 12/31 and today is 1/2. It is unclear to me whether
+                         * strotime will handle the conversion correctly ie. 12/31 will actually
+                         * be 12/31 of previous year and not the current. Thus I will make a
+                         * little check here. Will just append the previous year if now is less
+                         * then time_checked_out
+                         * ---------------------------------------------------------------------------- */
+                        if ( $now < $time_checkedout ) {
+                            $time_checkedout = strtotime ($line2[2] . "/" . (date("Y") - 1) . " " . $line2[3]);
+                        } else {
+                            // Get the time difference
+                            $t = new timespan( $now, $time_checkedout );
 
-                            // Output the user line
-                            $user_line = $used_license;
-                            $user_line_parts = explode( ' ', trim($user_line) );
-                            $user_line_formated = "<span>User: ".$user_line_parts[0]."</span> ";
-                            $user_line_formated .= "<span>Computer: ".$user_line_parts[2]."</span> ";
-                            $table->add_row(array("", "", $user_line_formated, $time_difference), $class);
+                            // Format the date string
+                            if ( $t->years > 0) $time_difference .= $t->years . " years(s), ";
+                            if ( $t->months > 0) $time_difference .= $t->months . " month(s), ";
+                            if ( $t->weeks > 0) $time_difference .= $t->weeks . " week(s), ";
+                            if ( $t->days > 0) $time_difference .= " " . $t->days . " day(s), ";
+                            if ( $t->hours > 0) $time_difference .= " " . $t->hours . " hour(s), ";
+                            $time_difference .= $t->minutes . " minute(s)";
                         }
+
+                        // Output the user line
+                        $user_line = $used_license;
+                        $user_line_parts = explode( ' ', trim($user_line) );
+                        $user_line_formated = "<span>User: ".$user_line_parts[0]."</span> ";
+                        $user_line_formated .= "<span>Computer: ".$user_line_parts[2]."</span> ";
+                        $table->add_row(array("", "", $user_line_formated, $time_difference), $class);
                     }
                 }
             }
+        }
 
-            // Display the table
-            if ($table->get_rows_count() > 2 ) {
-                $html_body .= $table->get_html();
-            }
-
-        } else {
-            // color #dc143c is "crimson", which is better than "red" for contrast ratio against white background.
-            $html_body .= "<p style='color: #dc143c;'>No licenses are currently being used on {$server['name']} ({$server['label']})</p>";
+        // Display the table
+        if ($table->get_rows_count() > 2 ) {
+            $html_body .= $table->get_html();
         }
         pclose($fp);
     } // END foreach ($servers as $server)
@@ -292,8 +292,10 @@ function get_features_and_licenses($server_id) {
     $query->bind_param(...$params);
     $query->execute();
     $query->bind_result($feature_name, $num_licenses);
-    while ($query->fetch()) {
-        $results[$feature_name]['num_licenses'] = $num_licenses;
+
+    for ($i = 0; $query->fetch(); $i++) {
+        $results[$i]['feature_name'] = $feature_name;
+        $results[$i]['num_licenses'] = $num_licenses;
     }
 
     if (!empty($db->error_list)) {

--- a/servers_admin.php
+++ b/servers_admin.php
@@ -206,19 +206,16 @@ function validate_uploaded_json() {
     case isset($tmp_name) && is_uploaded_file($tmp_name):
     case isset($type)     && $type  === "application/json":
     case isset($error)    && $error === 0:
-        log_var($_FILES, 2);
         return false;
     }
 
     $file = file_get_contents($tmp_name);
     if ($file === false) {
-        log_var($tmp_name, 3);
         return false;
     }
 
     $json = json_decode($file, true);
     if (is_null($json)) {
-        log_var($file, 4);
         return false;
     }
 
@@ -228,7 +225,6 @@ function validate_uploaded_json() {
         case array_key_exists('name', $row) && preg_match("/^\d{1,5}@(?:[a-z\d\-]+\.)+[a-z\-]{2,}$/i", $row['name']):
         case array_key_exists('label', $row);
         case array_key_exists('is_active', $row) && preg_match("/^[01]$/", $row['is_active']):
-            log_var($row, 5);
             return false;
         }
     }

--- a/style.css
+++ b/style.css
@@ -62,7 +62,7 @@ table.alt-rows-blue-bgcolor tr:nth-child(odd), tr.alt-odd-blue-bgcolor {
 }
 
 table.alt-rows-blue-bgcolor tr:nth-child(even), tr.alt-even-blue-bgcolor {
-    background-color: #e0efef;
+    background-color: #e1efef;
 }
 
 form.edit-form {

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 /* Do not rely on the browser for default values */
 body {
-    color: black;
-    background-color: white;
+    color: #000000; /* black */
+    background-color: #ffffff; /* white */
     font-size: 16px;
     font-family: Helvetica, Arial, sans-serif;
 }
@@ -17,12 +17,12 @@ a {
 
 /* Red (#ff0000) is too light for contrast ratio > 4.5:1 against white and #efefef. */
 .red-text {
-    color: firebrick;
+    color: #b22222; /* firebrick */
 }
 
 /* Green (#008000) is too light for contrast ratio < 4.5:1 against #efefef. */
 .green-text {
-    color: darkgreen;
+    color: #006400; /* darkgreen */
 }
 
 .float-right {
@@ -55,6 +55,14 @@ input[type=file].servers-control-panel {
 
 table.alt-rows-bgcolor tr:nth-child(even), tr.alt-bgcolor {
     background-color: #efefef;
+}
+
+table.alt-rows-blue-bgcolor tr:nth-child(odd), tr.alt-odd-blue-bgcolor {
+    background-color: #f0ffff; /* azure */
+}
+
+table.alt-rows-blue-bgcolor tr:nth-child(even), tr.alt-even-blue-bgcolor {
+    background-color: #e0efef;
 }
 
 form.edit-form {


### PR DESCRIPTION
Fix #79 "Wrong "Computer: /dev/tty" shown"
* Parse correct data field for user's host.

Fix #85 "Get Historical Graph When No Licenses Are In use"
* All features are now listed in the "usage details" view, with a link to view historical data graphs.
* Features with checked out licenses are sorted above features that do not have checked out licenses.
* Otherwise features are alphabetically sorted (not case sensitive).
* Features with checked out licenses also have an alternating blue tinted background.
* Features with no checked out licenses still use the original white/grey alternating background.

Fix #88 "Install Check Reported 32-bit Unix Timestamp on 64-bit OS"
* Test to check for 64-bit Unix time now relies on whether or not a time conversion of "9999-12-31" fails or succeeds.  This should make the test independent of time zones and other time drift variables.