### PR TITLE
license_alert.php bugfix

### DIFF
--- a/license_alert.php
+++ b/license_alert.php
@@ -61,11 +61,12 @@ for ($i = 0; $i < count($expiration_array); $i++) {
 // Dump the table HTML into a variable
 $table_html = $table->get_html();
 
-// Top of view.
+// View
 $message = <<<HTML
 These licenses will expire within {$lead_time} days.
 Licenses will expire at 23:59 on the day of expiration.
 <p>
+{$table_html}
 HTML;
 
 // If the table has more than one row (header row will be one) there are
@@ -75,10 +76,10 @@ if ($table->get_rows_count() > 1) {
         $message .= "Emailing to {$notify_address}<p>\n";
         $headers[] = 'MIME-Version: 1.0';
         $headers[] = 'Content-type: text/html; charset=iso-8859-1';
-        $headers[] = "From: {$do_not_reply_email}";
-        $headers[] = "Reply-To: {$do_not_reply_email}";
+        $headers[] = "From: {$do_not_reply_address}";
+        $headers[] = "Reply-To: {$do_not_reply_address}";
         $headers[] = 'X-Mailer: PHP/' . phpversion();
-        mail($notify_address, "ALERT: License expiration within {$lead_time} days", $message , implode("\r\n", $headers));
+        mail($notify_address, "ALERT: License expiration within {$lead_time} days", $message, implode("\r\n", $headers));
     }
 }
 
@@ -86,6 +87,5 @@ if ($table->get_rows_count() > 1) {
 print_header();
 print "<h1>License Alert</h1>\n";
 print $message;
-print $table_html;
 print_footer();
 ?>

--- a/license_alert.php
+++ b/license_alert.php
@@ -61,7 +61,7 @@ for ($i = 0; $i < count($expiration_array); $i++) {
 // Dump the table HTML into a variable
 $table_html = $table->get_html();
 
-// View
+// View body
 $message = <<<HTML
 These licenses will expire within {$lead_time} days.
 Licenses will expire at 23:59 on the day of expiration.
@@ -72,8 +72,8 @@ HTML;
 // If the table has more than one row (header row will be one) there are
 // expiring licenses alerts to be emailed.
 if ($table->get_rows_count() > 1) {
-    if ($notify_address && $do_not_reply_address && !isset($_GET['nomail'])) {
-        $message .= "Emailing to {$notify_address}<p>\n";
+    if (isset($notify_address) && isset($do_not_reply_address) && !isset($_GET['nomail'])) {
+        $message .= "Emailing to {$notify_address}\n";
         $headers[] = 'MIME-Version: 1.0';
         $headers[] = 'Content-type: text/html; charset=iso-8859-1';
         $headers[] = "From: {$do_not_reply_address}";


### PR DESCRIPTION
Fix #91 "Email Alerts are lacking details"
License expiration table should now be included in the email.
No-reply email address should be properly added to headers.
A few minor code tweaks.