### PR TITLE
Development php.ini

### DIFF
--- a/lmtools.php
+++ b/lmtools.php
@@ -244,7 +244,6 @@ class lmtools extends lmtools_lib {
                 if ($lmdata === false) return false;
             }
 
-            log_var($used_licenses, 99);
             return $used_licenses;
         }
 

--- a/vagrant_provision/pl/config.pm
+++ b/vagrant_provision/pl/config.pm
@@ -11,6 +11,9 @@ our @LMTOOLS_PATH = (rootdir(), "opt", "lmtools");
 our @HTML_PATH = (rootdir(), "var", "www", "html");
 our @LOGROTATE_PATH = (rootdir(), "etc", "logrotate.d");
 our @APACHE_PATH = (rootdir(), "etc", "apache2");
+our @PHP_INI_DEV_PATH = (rootdir(), "usr", "lib", "php", "7.4");
+our @PHP_INI_APACHE_PATH = (rootdir(), "etc", "php", "7.4", "apache2");
+our @PHP_INI_CLI_PATH = (rootdir(), "etc", "php", "7.4", "cli");
 our @CACHE_PATH = (rootdir(), "var", "cache", "phplw");
 
 # Relevant files
@@ -19,6 +22,8 @@ our $CONFIG_FILE = "config.php";
 our $SQL_FILE = "phplicensewatcher.sql";
 our $LOGROTATE_CONF_FILE = "phplw.conf";
 our $APACHE_CONF_FILE = "phplw.conf";
+our $PHP_INI_DEV_FILE = "php.ini-development";
+our $PHP_INI_FILE = "php.ini";
 our $UPDATE_CODE = "update_code.pl";
 our $LICENSE_UTIL = "license_util.php";
 our $LICENSE_CACHE = "license_cache.php";


### PR DESCRIPTION
- Copy over development php.ini for apache and cli.
- Set perms on /home/vagrant to 0777 so debugging logs can be written by www_data or whoever else needs to write logs.
- Remove unnecessary debug statement from lmtools.php.