### PR TITLE
Innodb Autoincrement Fix

### DIFF
--- a/footer.html
+++ b/footer.html
@@ -4,6 +4,6 @@
 </div> <!-- .col-lg-12 -->
 </div> <!-- .row -->
 <hr/><p><a href='https://github.com/rpi-dotcio/phpLicenseWatcher'>PHP License Watcher</a>
-<span class='float-right'>Build 2.210916</span></p>
+<span class='float-right'>Build 2.211221</span></p>
 </div> <!-- #main-wrap .container -->
 </body></html>

--- a/license_util.php
+++ b/license_util.php
@@ -172,7 +172,7 @@ function update_licenses(&$db, $servers) {
 } // END function update_licenses()
 
 /**
- * Print error to STDERR and exit 1.
+ * Print error to STDERR, close DB, and exit 1.
  *
  * die() is insufficient because it prints to STDOUT and exits 0.
  *

--- a/license_util.php
+++ b/license_util.php
@@ -58,7 +58,7 @@ function update_servers(&$db, $servers) {
         $query->bind_param("sss", $status[$index], $server_version[$index], $name[$index]);
         if ($query->execute() === false) {
             $db->rollback();
-            print_error_and_die("MySQL: {$query->error}");
+            print_error_and_die($db, "MySQL: {$query->error}");
         }
     }
     $db->commit();
@@ -73,13 +73,14 @@ function update_servers(&$db, $servers) {
  */
 function update_licenses(&$db, $servers) {
     // Setup DB queries
+    $queries = array();
 
     // Populate feature, if needed.
     // ? = $lmdata['feature']
     $sql = <<<SQL
     INSERT IGNORE INTO `features` (`name`, `show_in_lists`, `is_tracked`) VALUES (?, 1, 1);
     SQL;
-    $query_features = $db->prepare($sql);
+    $queries['features'] = $db->prepare($sql);
 
     // Populate server/feature to licenses, if needed.
     // ?, ? = $server['name'], $lmdata['feature']
@@ -88,7 +89,7 @@ function update_licenses(&$db, $servers) {
     SELECT DISTINCT `servers`.`id` AS `server_id`, `features`.`id` AS `feature_id` FROM `servers`, `features`
     WHERE `servers`.`name` = ? AND `features`.`name` = ?;
     SQL;
-    $query_licenses = $db->prepare($sql);
+    $queries['licenses'] = $db->prepare($sql);
 
     // Insert license usage.  Needs feature and license populated, first.
     // ?, ?, ? = $lmdata['licenses_used'], $server['name'], $lmdata['feature']
@@ -99,68 +100,75 @@ function update_licenses(&$db, $servers) {
     JOIN `features` ON `licenses`.`feature_id`=`features`.`id`
     WHERE `servers`.`name`=? AND `features`.`name`=? AND `features`.`is_tracked`=1;
     SQL;
-    $query_usage = $db->prepare($sql);
+    $queries['usage'] = $db->prepare($sql);
     // END setup DB queries.
 
+    // Allows us to use exception handling of MySQL.
+    mysqli_report(MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT);
+
+    // Get current autocommit status.  This will be restored after we're done.
+    $result = $db->query("SELECT @@autocommit", MYSQLI_STORE_RESULT);
+    $reset_autocommit = (bool) $result->fetch_row()[0];
+
+    // MySQL transactions and table locks don't play well together, so we'll
+    // disable autocommit before locking tables for writing.
+    $db->autocommit(false);
+    $db->query("LOCK TABLES `features` WRITE, `servers` READ, `licenses` WRITE, `usage` WRITE;");
+
     $lmtools = new lmtools();
-    $db->begin_transaction(MYSQLI_TRANS_START_READ_WRITE);
     foreach ($servers as $server) {
         if ($lmtools->lm_open($server['license_manager'], 'license_util__update_licenses', $server['name']) === false) {
-            $db->rollback();
-            print_error_and_die($lmtools->err);
+            db_cleanup($db, $queries, $reset_autocommit);
+            print_error_and_die($db, $lmtools->err);
         }
         $lmdata = $lmtools->lm_nextline();
         if ($lmdata === false) {
-            $db->rollback();
-            print_error_and_die($lmtools->err);
+            db_cleanup($db, $queries, $reset_autocommit);
+            print_error_and_die($db, $lmtools->err);
         }
         // INSERT license data to DB
         while (!is_null($lmdata)) {
             // $lmdata['licenses_used'] will be missing when the feature has no license count ("uncounted").
             // But `usage`.`num_users` in the DB can't be null, so we'll fill in '0'.
-            if (!isset($lmdata['licenses_used'])) $lmdata['licenses_used'] = 0;
+            if (!array_key_exists('licenses_used', $lmdata)) $lmdata['licenses_used'] = 0;
 
-            // bind data to prepared queries.
-            $query_features->bind_param("s", $lmdata['feature']);
-            $query_licenses->bind_param("ss", $server['name'], $lmdata['feature']);
-            $query_usage->bind_param("iss", $lmdata['licenses_used'], $server['name'], $lmdata['feature']);
+            // DB operations
+            try {
+                // Attempt to INSERT license usage...
+                $queries['usage']->bind_param("iss", $lmdata['licenses_used'], $server['name'], $lmdata['feature']);
+                $queries['usage']->execute();
 
-            // Attempt to INSERT license usage...
-            if ($query_usage->execute() === false) {
-                $db->rollback();
-                print_error_and_die("MySQL: {$query_usage->error}");
-            }
+                // when affectedRows < 1, we will attempt to populate features
+                // and licenses and re-run usage query.
+                // 'INSERT IGNORE' in queries prevents unique key collisions.
+                if ($db->affected_rows < 1) {
+                    // Features table
+                    $queries['features']->bind_param("s", $lmdata['feature']);
+                    $queries['features']->execute();
 
-            // when affectedRows < 1, feature and license first needs to be
-            // populated and then license usage query re-run.
-            if ($db->affected_rows < 1) {
-                switch (false) {
-                case $query_features->execute():
-                    $db->rollback();
-                    print_error_and_die("MySQL: {$query_features->error}");
-                case $query_licenses->execute():
-                    $db->rollback();
-                    print_error_and_die("MySQL: {$query_licenses->error}");
-                case $query_usage->execute():
-                    $db->rollback();
-                    print_error_and_die("MySQL: {$query_usage->error}");
+                    // Licenses table
+                    $queries['licenses']->bind_param("ss", $server['name'], $lmdata['feature']);
+                    $queries['licenses']->execute();
+
+                    // Usage table
+                    $queries['usage']->execute();
                 }
+            } catch (mysqli_sql_exception $e) {
+                db_cleanup($db, $queries, $reset_autocommit);
+                print_error_and_die($db, $e->getMessage());
             }
 
             // Get another data set from license manager.
             $lmdata = $lmtools->lm_nextline();
             if ($lmdata === false) {
-                $db->rollback();
-                print_error_and_die($lmtools->err);
+                db_cleanup($db, $queries, $reset_autocommit);
+                print_error_and_die($db, $lmtools->err);
             }
-        } // END while(!is_null($lmdata())
+        } // END while(!is_null($lmdata))
     } // END foreach($servers as $server)
 
     // Complete and cleanup
-    $db->commit();
-    $query_usage->close();
-    $query_licenses->close();
-    $query_features->close();
+    db_cleanup($db, $queries, $reset_autocommit);
 } // END function update_licenses()
 
 /**
@@ -168,10 +176,38 @@ function update_licenses(&$db, $servers) {
  *
  * die() is insufficient because it prints to STDOUT and exits 0.
  *
+ * @param &$db Database connection object.
  * @param $msg error message
  */
-function print_error_and_die($msg) {
+function print_error_and_die(&$db, $msg) {
     fprintf(STDERR, "%s\n", $msg);
+    $db->close();
     exit(1);
+}
+
+/**
+ * Commit DB queries, reset auto-increment counter, unlock tables, and close prepared statements.
+ *
+ * InnoDB will increment an auto-increment ID when a feature is not tracked, but
+ * did exist.  We don't want this, so the auto-increment counters are manually
+ * set back to max(id)+1.
+ *
+ * @param &$db Database connection object.
+ * @param &$queries Array of prepared queries (statements) to be closed.
+ * @param $reset_autoincrement The DB's auto increment state to be restored.
+ */
+function db_cleanup(&$db, &$queries, $reset_autocommit) {
+    $db->commit();
+
+    // Reset auto-increment ID columns for features and licenses
+    foreach (array("features", "licenses") as $table) {
+        $result = $db->query("SELECT max(id)+1 FROM `{$table}`;", MYSQLI_STORE_RESULT);
+        $max_id = $result->fetch_row()[0];
+        $db->query("ALTER TABLE `{$table}` AUTO_INCREMENT = {$max_id};");
+    }
+
+    $db->query("UNLOCK TABLES;");
+    $db->autocommit($reset_autocommit);
+    foreach ($queries as &$query) $query->close();
 }
 ?>


### PR DESCRIPTION
Fix #101
license_util.php
- Now explicitly locks tables for inserting or updating features, licenses, and usage.
- Table locks and transactions don't play nicely in MySQL (according to documentation), so transactions have been replaced by turning off autocommit.  This still should allow rollback on error.
- Reset auto increment counter for ID columns in features and licenses tables to `max(id)+1`