### PR TITLE
Server Name and Mathematica Regex EOL

### DIFF
--- a/common.php
+++ b/common.php
@@ -217,7 +217,7 @@ function print_var ($var) {
  * "var0.txt", "var1.txt", etc.  If the files aren't being written, it is
  * likely a permissions issue.  $ chmod ugo+w /home/vagrant
  *
- * @param mixed $var variable to be exported to browser view.
+ * @param mixed $var variable to be exported to file.
  */
 function log_var($var, $num=0) {
     global $debug; // from config.php

--- a/footer.html
+++ b/footer.html
@@ -4,6 +4,6 @@
 </div> <!-- .col-lg-12 -->
 </div> <!-- .row -->
 <hr/><p><a href='https://github.com/rpi-dotcio/phpLicenseWatcher'>PHP License Watcher</a>
-<span class='float-right'>Build 2.210916</span></p>
+<span class='float-right'>Build 2.220105</span></p>
 </div> <!-- #main-wrap .container -->
 </body></html>

--- a/lmtools.php
+++ b/lmtools.php
@@ -16,11 +16,13 @@ class lmtools extends lmtools_lib {
     private $regex;
     public $err;
 
-    static public function validate_servername($name, $lm, &$is_valid, &$format) {
-        $pattern  = lmtools_lib::$_namecheck_regex[$lm]['pattern'];
-        $is_valid = preg_match($pattern, $name);
-        $format   = lmtools_lib::$_namecheck_regex[$lm]['format'];
-    }
+    /* Not currently in use and needs updating to permit hostname and ipv4.
+       This also includes lmtools_lib::$_namecheck_regex[].                   */
+    // static public function validate_servername($name, $lm, &$is_valid, &$format) {
+    //     $pattern  = lmtools_lib::$_namecheck_regex[$lm]['pattern'];
+    //     $is_valid = preg_match($pattern, $name);
+    //     $format   = lmtools_lib::$_namecheck_regex[$lm]['format'];
+    // }
 
     public function __construct() {
         clearstatcache();

--- a/lmtools_lib.php
+++ b/lmtools_lib.php
@@ -93,13 +93,14 @@ Regex pattern "/(?:[a-z\d\-]+\.)+[a-z\-]{2,}/i" should well represent most FQDNs
 ***This has not yet been implemented elsewhere in phplw.
 * --------------------------------------------------------------------------- */
 
-    static protected $_namecheck_regex = [
-        'flexlm' => [
-            'format'  => "port@doman.tld",
-            'pattern' => "/^\d{1,5}@(?:[a-z\d\-]+\.)+[a-z\-]{2,}$/i"],
-        'mathematica' => [
-            'format'  => "domain.tld",
-            'pattern' => "/^(?:[a-z\d\-]+\.)+[a-z\-]{2,}$/i"]];
+    /* Currently unused and needs updating to permit hostname and ipv4        */
+    // static protected $_namecheck_regex = [
+    //     'flexlm' => [
+    //         'format'  => "port@doman.tld",
+    //         'pattern' => "/^\d{1,5}@(?:[a-z\d\-]+\.)+[a-z\-]{2,}$/i"],
+    //     'mathematica' => [
+    //         'format'  => "domain.tld",
+    //         'pattern' => "/^(?:[a-z\d\-]+\.)+[a-z\-]{2,}$/i"]];
 
     static protected function get_dateinterval($date = null, $time = null, $duration = null) {
         // Create DateInterval based on either $date/$time or $duration.

--- a/lmtools_lib.php
+++ b/lmtools_lib.php
@@ -38,7 +38,7 @@ STRING CONSTANTS
             'regex' => ["/(?:INCREMENT|FEATURE) (?<name>[^ ]+) (?<vendor_daemon>[^ ]+) [^ ]+ (?<expiration_date>[^ ]+) (?<num_licenses>[^ ]+)/i"]],
         'mathematica' => [
             'cli'   => "%CLI_BINARY% %CLI_SERVER% -template " . __DIR__ . "/mathematica/tools__build_license_expiration_array.template",
-            'regex' => ["/^(?<name>[^:]+):\s+(?<vendor_daemon>[^ ]+)\s+(?<expiration_date>[^ ]+)\s+(?<num_licenses>[^ ]+)$/i"]]];
+            'regex' => ["/^(?<name>[^:]+):\s+(?<vendor_daemon>[^ ]+)\s+(?<expiration_date>[^ ]+)\s+(?<num_licenses>[^ ]+)\s*$/i"]]];
 
     static protected $license_cache = [
         'flexlm' => [
@@ -46,7 +46,7 @@ STRING CONSTANTS
             'regex' => ["/^Users of (?<feature>[^ ]+):  \(Total of (?<num_licenses>\d+)/"]],
         'mathematica' => [
             'cli'   => "%CLI_BINARY% %CLI_SERVER% -template " . __DIR__ . "/mathematica/license_cache.template",
-            'regex' => ["/^(?<feature>[^:]+):\s+(?<num_licenses>\d+)$/"]]]; // placeholder
+            'regex' => ["/^(?<feature>[^:]+):\s+(?<num_licenses>\d+)\s*$/"]]];
 
     static protected $license_util__update_servers = [
         'flexlm' => [
@@ -57,7 +57,7 @@ STRING CONSTANTS
         'mathematica' => [
             'cli'   => "%CLI_BINARY% %CLI_SERVER% -template " . __DIR__ . "/mathematica/license_util__update_servers.template",
             'regex' => [
-                'server_up' => "/^(?<server_version>v\d+(?:\.\d+)+)/"]]];  // placeholders
+                'server_up' => "/^(?<server_version>v\d+(?:\.\d+)+)\s*$/"]]];
 
     static protected $license_util__update_licenses = [
         'flexlm' => [
@@ -65,7 +65,7 @@ STRING CONSTANTS
             'regex' => ["/^Users of (?<feature>[^ ]+):  (?:\(Total of \d+ licenses? issued;  Total of (?<licenses_used>\d+)|(?:\(Uncounted))/"]],
         'mathematica' => [
             'cli'   => "%CLI_BINARY% %CLI_SERVER% -template " . __DIR__ . "/mathematica/license_util__update_licenses.template",
-            'regex' => ["/^(?<feature>[^:]+):\s+(?<licenses_used>\d+)$/"]]]; // placeholder
+            'regex' => ["/^(?<feature>[^:]+):\s+(?<licenses_used>\d+)\s*$/"]]];
 
     static protected $self__get_license_usage_array = [
         'flexlm' => [
@@ -77,8 +77,8 @@ STRING CONSTANTS
         'mathematica' => [
             'cli'   => "%CLI_BINARY% %CLI_SERVER% -localtime -template " . __DIR__ . "/mathematica/details__list_licenses_in_use.template",
             'regex' => [
-                'users_counted'   => "/^COUNTS (?<feature>[^:]+):\s+(?<used_licenses>\d+)\s+(?<total_licenses>\d+)$/",  // placeholders
-                'details'         => "/^DETAILS (?<feature>[^:]+): (?<user>[^~]+)~(?<host>[^~]+)~(?<duration>\d+(?::\d+)+)$/"]]];
+                'users_counted'   => "/^COUNTS (?<feature>[^:]+):\s+(?<used_licenses>\d+)\s+(?<total_licenses>\d+)\s*$/",
+                'details'         => "/^DETAILS (?<feature>[^:]+): (?<user>[^~]+)~(?<host>[^~]+)~(?<duration>\d+(?::\d+)+)\s*$/"]]];
 
 
 /* --------------------------------------------------------------------------- *

--- a/lmtools_lib.php
+++ b/lmtools_lib.php
@@ -57,7 +57,7 @@ STRING CONSTANTS
         'mathematica' => [
             'cli'   => "%CLI_BINARY% %CLI_SERVER% -template " . __DIR__ . "/mathematica/license_util__update_servers.template",
             'regex' => [
-                'server_up' => "/^(?<server_version>v\d+(?:\.\d+)+)$/"]]];  // placeholders
+                'server_up' => "/^(?<server_version>v\d+(?:\.\d+)+)/"]]];  // placeholders
 
     static protected $license_util__update_licenses = [
         'flexlm' => [

--- a/servers_admin.php
+++ b/servers_admin.php
@@ -175,7 +175,7 @@ function edit_form() {
     <h1>Server Details</h1>
     <form action='servers_admin.php' method='post' class='edit-form'>
         <div class='edit-form block'>
-            <label for='name'>Name (format: <code>port@domain</code> or <code>port@ip</code>, port optional)</label><br>
+            <label for='name'>Name (format: <code>port@domain</code> or <code>port@ipv4</code>, port optional)</label><br>
             <input type='text' name='name' id='name' class='edit-form' value='{$server_details['name']}'>
         </div><div class='edit-form block'>
             <label for='label'>Label</label><br>

--- a/servers_admin.php
+++ b/servers_admin.php
@@ -175,7 +175,7 @@ function edit_form() {
     <h1>Server Details</h1>
     <form action='servers_admin.php' method='post' class='edit-form'>
         <div class='edit-form block'>
-            <label for='name'>Name (format: <code>port@domain.tld</code>, port optional)</label><br>
+            <label for='name'>Name (format: <code>port@domain</code> or <code>port@ip</code>, port optional)</label><br>
             <input type='text' name='name' id='name' class='edit-form' value='{$server_details['name']}'>
         </div><div class='edit-form block'>
             <label for='label'>Label</label><br>

--- a/servers_admin.php
+++ b/servers_admin.php
@@ -126,7 +126,7 @@ function main_form($alert=null) {
     <script src="servers_admin_jquery.js"></script>
     <h1>Server Administration</h1>
     <p>You may edit an existing server's name, label, active status, or add a new server to the database.<br>
-    Server names must be unique and in the form of "<code>port@domain.tld</code>", port optional.
+    Server names must be unique and in the form of <code>port@domain.tld</code>, <code>port@hostname</code>, or <code>port@ipv4</code>.  Port is optional, but must unprivileged.
     {$alert_html}
     {$control_panel_html}
     <form id='server_list' action='servers_admin.php' method='POST'>
@@ -175,7 +175,7 @@ function edit_form() {
     <h1>Server Details</h1>
     <form action='servers_admin.php' method='post' class='edit-form'>
         <div class='edit-form block'>
-            <label for='name'>Name (format: <code>port@domain</code> or <code>port@ipv4</code>, port optional)</label><br>
+            <label for='name'>Name (format: <code>port@domain</code>, <code>port@host</code>, <code>port@ipv4</code>, port optional.)</label><br>
             <input type='text' name='name' id='name' class='edit-form' value='{$server_details['name']}'>
         </div><div class='edit-form block'>
             <label for='label'>Label</label><br>

--- a/servers_admin.php
+++ b/servers_admin.php
@@ -231,12 +231,13 @@ function validate_uploaded_json() {
     }
 
     foreach ($json as $row) {
+        // validate_server_name() is defined in servers_admin_db.php
         switch (false) {
         case is_array($row):
         case array_key_exists('license_manager', $row):
-        case array_key_exists('name', $row) && preg_match("/^(?:\d{1,5}@)?(?:[a-z\d\-]+\.)+[a-z\-]{2,}$/i", $row['name']):
+        case array_key_exists('name', $row) && validate_server_name($row['name']):
         case array_key_exists('label', $row):
-        case array_key_exists('is_active', $row) && preg_match("/^[01]$/", $row['is_active']):
+        case array_key_exists('is_active', $row) && preg_match("/^[01]$/", $row['is_active']) === 1:
             return false;
         }
     }

--- a/servers_admin_db.php
+++ b/servers_admin_db.php
@@ -153,11 +153,13 @@ function validate_server_name(string $name) : bool {
             return false;
         }
         // Octets only exist in third regex check (for valid ipv4).
+        // $octet array keys only exist when matching the third regex.
         foreach (array('octet1', 'octet2', 'octet3', 'octet4') as $octet) {
-            if (!is_null($matches[$octet]) && ((int) $matches[$octet] < 0 || (int) $matches[$octet] > 255)) {
+            if (array_key_exists($matches, $octet) && ((int) $matches[$octet] < 0 || (int) $matches[$octet] > 255)) {
                 return false;
             }
         }
+
         return true;
     default:
         // No regex matches mean $name is definitely invalid.

--- a/servers_admin_db.php
+++ b/servers_admin_db.php
@@ -145,16 +145,16 @@ function db_import_servers_json($json) {
 function validate_server_name(string $name) : bool {
     // Regex checks are order of: (1) port@domain.tld  (2) port@hostname  (3) port@ipv4
     switch (true) {
-    case preg_match("/^(?:(?<port>\d{1,5})@)?(?:(?!\-)[a-z0-9\-]+(?<!\-)\.)+[a-z\-]{2,}$/i", $name, $matches) === 1:
-    case preg_match("/^(?:(?<port>\d{1,5})@)?(?!\-)[a-z0-9\-]+(?<!\-)$/i", $name, $matches) === 1:
-    case preg_match("/^(?:(?<port>\d{1,5})@)?(?<octet1>\d{1,3})\.(?<octet2>\d{1,3})\.(?<octet3>\d{1,3})\.(?<octet4>\d{1,3})$/", $name, $matches) === 1:
+    case preg_match("/^(?:(?<port>\d{1,5})@)?(?:(?!\-)[a-z0-9\-]+(?<!\-)\.)+[a-z\-]{2,}$/i", $name, $matches, PREG_UNMATCHED_AS_NULL) === 1:
+    case preg_match("/^(?:(?<port>\d{1,5})@)?(?!\-)[a-z0-9\-]+(?<!\-)$/i", $name, $matches, PREG_UNMATCHED_AS_NULL) === 1:
+    case preg_match("/^(?:(?<port>\d{1,5})@)?(?<octet1>\d{1,3})\.(?<octet2>\d{1,3})\.(?<octet3>\d{1,3})\.(?<octet4>\d{1,3})$/", $name, $matches, PREG_UNMATCHED_AS_NULL) === 1:
         // Port is optional since Mathematica doesn't specify a port.
-        if (array_key_exists('port', $matches) && ((int) $matches['port'] < 1024 || (int) $matches['port'] > 65535)) {
+        if (!is_null($matches['port']) && ((int) $matches['port'] < 1024 || (int) $matches['port'] > 65535)) {
             return false;
         }
         // Octets only exist in third regex check (for valid ipv4).
         foreach (array('octet1', 'octet2', 'octet3', 'octet4') as $octet) {
-            if (array_key_exists($octet, $matches) && ((int) $matches[$octet] < 0 || (int) $matches[$octet] > 255)) {
+            if (!is_null($matches[$octet]) && ((int) $matches[$octet] < 0 || (int) $matches[$octet] > 255)) {
                 return false;
             }
         }

--- a/servers_admin_db.php
+++ b/servers_admin_db.php
@@ -15,8 +15,8 @@ function db_process() {
     case preg_match("/^\d+$|^new$/", $id):
         return array('msg' => "Invalid server ID \"{$id}\"", 'lvl' => "failure");
     // $name must be valid (depends on license manager)
-    case preg_match("/^(?:\d{1,5}@)?(?:[a-z\d\-]+\.)+[a-z\-]{2,}$/i", $name);
-        return array('msg' => "Server name MUST be in form <code>port@domain.tld</code>, port optional", 'lvl' => "failure");
+    case preg_match("/^(?:[1-6]?\d{1,4}@)?(?:(?:(?:[a-z\d\-]+\.)+[a-z\-]{2,})|[a-z\d\-]+|(?:(?:[12]?\d{1,2}\.){3}[12]?\d{1,2}))$/i", $name);
+        return array('msg' => "Server name MUST be in form <code>port@domain</code> or <code>port@ip</code>, port optional", 'lvl' => "failure");
     // $label cannot be blank
     case !empty($label):
         return array('msg' => "Server's label cannot be blank", 'lvl' => "failure");

--- a/servers_admin_db.php
+++ b/servers_admin_db.php
@@ -155,7 +155,7 @@ function validate_server_name(string $name) : bool {
         // Octets only exist in third regex check (for valid ipv4).
         // $octet array keys only exist when matching the third regex.
         foreach (array('octet1', 'octet2', 'octet3', 'octet4') as $octet) {
-            if (array_key_exists($matches, $octet) && ((int) $matches[$octet] < 0 || (int) $matches[$octet] > 255)) {
+            if (array_key_exists($octet, $matches) && ((int) $matches[$octet] < 0 || (int) $matches[$octet] > 255)) {
                 return false;
             }
         }


### PR DESCRIPTION
Fix #103 
- Servers can now be named `port@domain.tld`, `port@hostname`, or `port@ipv4`.  Port is optional (as Mathematica doesn't require a specified port), but port must be unprivileged (port 1024 or higher).

Fix #106 
- This is an edge case that doesn't affect all servers.  Added `\s*` before `$` to better match `\r\n` at end of string while also accepting `\n` EOL.