### PR TITLE
Email License Alert Reports By SMTP

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,7 +67,10 @@ dist/
 nbdist/
 .nb-gradle/
 
+# VS Code
+.code-workspace
+
 # Composer
 /vendor/
-composer.lock
+!composer.lock
 !composer.json

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,8 @@ nbdist/
 .code-workspace
 
 # Composer
+composer
+composer.phar
 /vendor/
 !composer.lock
 !composer.json

--- a/check_installation.php
+++ b/check_installation.php
@@ -3,6 +3,11 @@
 require_once __DIR__ . "/common.php";
 include_once __DIR__ . "/html_table.php";
 
+if (file_exists(__DIR__ . "/vendor/autoload.php")) {
+    require_once __DIR__ . "/vendor/autoload.php";
+}
+use PHPMailer\PHPMailer\PHPMailer;
+
 define("PASS_MARK", "<span class='green-text'>&#10004; GOOD</span>");  // green heavy checkmark
 define("FAIL_MARK", "<span class='red-text'>&#10006; FAIL</span>");    // red cross mark
 define("REQUIRED_PHP", "7.3.0");
@@ -51,10 +56,10 @@ $test = call_user_func(function() {
     global $db_hostname, $db_username, $db_password, $db_database; // from config.php
 
     $err = array();
-    if (!isset($db_hostname)) $err[] = '$db_hostname';
-    if (!isset($db_username)) $err[] = '$db_username';
-    if (!isset($db_password)) $err[] = '$db_password';
-    if (!isset($db_database)) $err[] = '$db_database';
+    if (!isset($db_hostname) || empty($db_hostname)) $err[] = '$db_hostname';
+    if (!isset($db_username) || empty($db_username)) $err[] = '$db_username';
+    if (!isset($db_password) || empty($db_password)) $err[] = '$db_password';
+    if (!isset($db_database) || empty($db_database)) $err[] = '$db_database';
     if (!empty($err)) {
         $err = implode(", ", $err);
         return array(false, "{$err} not set in config.php");
@@ -73,6 +78,13 @@ $test = call_user_func(function() {
 $test_names   = "Database Connectivity";
 $test_values  = $test[0] ? "Connection OK" : $test[1];
 $test_results = $test[0] ? PASS_MARK : FAIL_MARK;
+$table->add_row(array($test_names, $test_values, $test_results));
+
+// Test to see if PHPMailer exists via composer
+$test         = class_exists("PHPMailer\PHPMailer\PHPMailer", true);
+$test_names   = "PHPMailer Library (via Composer)";
+$test_values  = $test ? "Library Found" : "Library NOT Found";
+$test_results = $test ? PASS_MARK : FAIL_MARK;
 $table->add_row(array($test_names, $test_values, $test_results));
 
 // Display view.

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "phpmailer/phpmailer": "^6.6.5"
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,97 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "fa4afa6d4d91c471343e8806b31e922e",
+    "packages": [
+        {
+            "name": "phpmailer/phpmailer",
+            "version": "v6.6.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPMailer/PHPMailer.git",
+                "reference": "8b6386d7417526d1ea4da9edb70b8352f7543627"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPMailer/PHPMailer/zipball/8b6386d7417526d1ea4da9edb70b8352f7543627",
+                "reference": "8b6386d7417526d1ea4da9edb70b8352f7543627",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-hash": "*",
+                "php": ">=5.5.0"
+            },
+            "require-dev": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7.0",
+                "doctrine/annotations": "^1.2",
+                "php-parallel-lint/php-console-highlighter": "^1.0.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcompatibility/php-compatibility": "^9.3.5",
+                "roave/security-advisories": "dev-latest",
+                "squizlabs/php_codesniffer": "^3.6.2",
+                "yoast/phpunit-polyfills": "^1.0.0"
+            },
+            "suggest": {
+                "ext-mbstring": "Needed to send email in multibyte encoding charset or decode encoded addresses",
+                "hayageek/oauth2-yahoo": "Needed for Yahoo XOAUTH2 authentication",
+                "league/oauth2-google": "Needed for Google XOAUTH2 authentication",
+                "psr/log": "For optional PSR-3 debug logging",
+                "symfony/polyfill-mbstring": "To support UTF-8 if the Mbstring PHP extension is not enabled (^1.2)",
+                "thenetworg/oauth2-azure": "Needed for Microsoft XOAUTH2 authentication"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPMailer\\PHPMailer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-2.1-only"
+            ],
+            "authors": [
+                {
+                    "name": "Marcus Bointon",
+                    "email": "phpmailer@synchromedia.co.uk"
+                },
+                {
+                    "name": "Jim Jagielski",
+                    "email": "jimjag@gmail.com"
+                },
+                {
+                    "name": "Andy Prevost",
+                    "email": "codeworxtech@users.sourceforge.net"
+                },
+                {
+                    "name": "Brent R. Matzelle"
+                }
+            ],
+            "description": "PHPMailer is a full-featured email creation and transfer class for PHP",
+            "support": {
+                "issues": "https://github.com/PHPMailer/PHPMailer/issues",
+                "source": "https://github.com/PHPMailer/PHPMailer/tree/v6.6.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/Synchro",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-10-07T12:23:10+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
+}

--- a/config/sample-config.php
+++ b/config/sample-config.php
@@ -15,11 +15,20 @@ $cache_dir="/var/cache/phplw/";
 $cache_lifetime=7200;
 
 // License expiration alerts are sent to $notify_address.
-// $do_not_reply_address is filled in the reply field.
-// License alert emails are disabled when either is left blank.
+// $reply_address is filled in the from and reply fields.
+// Consider NOT using a "do not reply" address so that errors can be received.
+// $smtp_tls is either "smtps" or "starttls".
+// $smtp_port is usually either "465" (smtps) or "587" (starttls).
+// License alert emails are disabled when $send_email_notifications is set 0.
 // Licenses expiring within $lead_time (in days) are included in the alerts.
+$smtp_host="";
+$smtp_login="";
+$smtp_password="";
+$smtp_tls="";
+$smtp_port="";
 $notify_address="";
-$do_not_reply_address="";
+$reply_address="";
+$send_email_notifications=0;
 $lead_time=30;
 
 // $disable_autorefresh, when set to 1, will halt automatic refresh of certain

--- a/footer.html
+++ b/footer.html
@@ -4,6 +4,6 @@
 </div> <!-- .col-lg-12 -->
 </div> <!-- .row -->
 <hr/><p><a href='https://github.com/rpi-dotcio/phpLicenseWatcher'>PHP License Watcher</a>
-<span class='float-right'>Build 2.220926</span></p>
+<span class='float-right'>Build 2.221109</span></p>
 </div> <!-- #main-wrap .container -->
 </body></html>

--- a/footer.html
+++ b/footer.html
@@ -4,6 +4,6 @@
 </div> <!-- .col-lg-12 -->
 </div> <!-- .row -->
 <hr/><p><a href='https://github.com/rpi-dotcio/phpLicenseWatcher'>PHP License Watcher</a>
-<span class='float-right'>Build 2.221109</span></p>
+<span class='float-right'>Build 2.221114</span></p>
 </div> <!-- #main-wrap .container -->
 </body></html>

--- a/header.html
+++ b/header.html
@@ -35,7 +35,7 @@
                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Admin <span class="caret"></span></a>
                     <ul class="dropdown-menu">
                         <li><a href="check_installation.php">Check Installation</a></li>
-                        <li><a href="license_alert.php?nomail=1">License Alert</a></li>
+                        <li><a href="license_alert.php">License Alert</a></li>
                         <li><a href="servers_admin.php">Servers Administration</a></li>
                         <li><a href="features_admin.php">Features Administration</a></li>
                         <!-- <li role="separator" class="divider"></li>-->

--- a/license_alert.php
+++ b/license_alert.php
@@ -1,3 +1,4 @@
+#!/usr/bin/env php
 <?php
 ############################################################################
 # Purpose: This script is used to e-mail alerts on licenses that are
@@ -11,6 +12,13 @@
 require_once __DIR__ . "/common.php";
 require_once __DIR__ . "/tools.php";
 require_once __DIR__ . "/html_table.php";
+
+if (file_exists(__DIR__ . "/vendor/autoload.php")) {
+    require_once __DIR__ . "/vendor/autoload.php";
+}
+use PHPMailer\PHPMailer\PHPMailer;
+use PHPMailer\PHPMailer\SMTP;
+use PHPMailer\PHPMailer\Exception;
 
 db_connect($db);
 $servers = db_get_servers($db, array('name', 'label', 'license_manager'));
@@ -34,7 +42,7 @@ $table->add_row($colHeaders, array(), "th");
 
 // Now after the expiration has been built loop through all the fileservers
 for ($i = 0; $i < count($expiration_array); $i++) {
-    if (isset($expiration_array[$i])) {
+    if (array_key_exists($i, $expiration_array)) {
         foreach ($expiration_array[$i] as $key => $myarray) {
             for ($j = 0; $j < sizeof($myarray); $j++) {
                 $bgcolor_class = "";
@@ -79,23 +87,68 @@ Licenses will expire at 23:59 on the day of expiration.
 {$table_html}
 HTML;
 
-// If the table has more than one row (header row will be one) there are
-// expiring licenses alerts to be emailed.
-if ($table->get_rows_count() > 1) {
-    if (isset($notify_address) && isset($do_not_reply_address) && !isset($_GET['nomail'])) {
-        $message .= "Emailing to {$notify_address}\n";
-        $headers[] = 'MIME-Version: 1.0';
-        $headers[] = 'Content-type: text/html; charset=iso-8859-1';
-        $headers[] = "From: {$do_not_reply_address}";
-        $headers[] = "Reply-To: {$do_not_reply_address}";
-        $headers[] = 'X-Mailer: PHP/' . phpversion();
-        mail($notify_address, "ALERT: License expiration within {$lead_time} days", $message, implode("\r\n", $headers));
+// More reliable check to determine if we're running on CLI than php_sapi_name()
+if (empty(preg_grep("/^HTTP_/", array_keys($_SERVER)))) {
+    // Script run from command line.  Send license alerts via email.
+    global $send_email_notifications;  // defined in config.php
+    if ($send_email_notifications) {
+        send_email($message);
+    }
+} else {
+    print_view($message);
+}
+
+exit(0);
+
+
+function send_email($message) {
+    // Check for PHPMailer library before proceeding.
+    if (!class_exists("PHPMailer\PHPMailer\PHPMailer", true)) {
+        fprintf(STDERR, "Cannot mail license alerts.  PHPMailer library not found.\n");
+        exit(1);
+    }
+
+    // globals are defined in config.php
+    global $smtp_host, $smtp_login, $smtp_password, $smtp_tls, $smtp_port, $notify_address, $reply_address, $lead_time;
+
+    $mail = new PHPMailer(true);
+    $mail->isSMTP();
+    $mail->SMTPAuth  = true;
+    $mail->Host      = $smtp_host;
+    $mail->Port      = $smtp_port;
+    $mail->Username  = $smtp_login;
+    $mail->Password  = $smtp_password;
+
+    switch ($smtp_tls) {
+    case "smtps":
+        $mail->SMTPSecure = PHPMailer::ENCRYPTION_SMTPS;
+        break;
+    case "starttls":
+        $mail->SMTPSecure = PHPMailer::ENCRYPTION_STARTTLS;
+        break;
+    default:
+        fprintf(STDERR, "Cannot mail license alerts.\n\$smtp_tls not properly set in config.php\n");
+        exit(1);
+    }
+
+    $mail->setFrom($reply_address, 'phpLicenseWatcher');
+    $mail->addReplyTo($reply_address);
+    $mail->addAddress($notify_address);
+    $mail->isHTML(true);
+
+    $mail->Subject = "ALERT: License expiration within {$lead_time} days";
+    $mail->Body    = $message;
+
+    if (!$mail->send()) {
+        fprintf(STDERR, "Cannot mail license alerts.\nMailer Error: %s", $mail->ErrorInfo);
+        exit(1);
     }
 }
 
-// Print View
-print_header();
-print "<h1>License Alert</h1>\n";
-print $message;
-print_footer();
+function print_view($message) {
+    print_header();
+    print "<h1>License Alert</h1>\n";
+    print $message;
+    print_footer();
+}
 ?>

--- a/vagrant_provision/pl/config.pm
+++ b/vagrant_provision/pl/config.pm
@@ -29,6 +29,7 @@ our $UPDATE_CODE = "update_code.pl";
 our $LICENSE_UTIL = "license_util.php";
 our $LICENSE_CACHE = "license_cache.php";
 our $COMPOSER_PACKAGES = "vendor";
+our @COMPOSER_CODE_FILES = qw(*);
 
 # Packages needed for phplw.
 our @REQUIRED_PACKAGES = ("apache2", "php", "php-mysql", "mysql-server", "mysql-client", "lsb", "wget", "zip", "unzip");

--- a/vagrant_provision/pl/config.pm
+++ b/vagrant_provision/pl/config.pm
@@ -18,7 +18,7 @@ our @PHP_INI_CLI_PATH = (rootdir(), "etc", "php", "8.1", "cli");
 our @CACHE_PATH = (rootdir(), "var", "cache", "phplw");
 
 # Relevant files
-our @CODE_FILES = qw(*.php *.html *.js *.css *.template mathematica vendor);
+our @CODE_FILES = qw(*.php *.html *.js *.css *.template mathematica);
 our $CONFIG_FILE = "config.php";
 our $SQL_FILE = "phplicensewatcher.sql";
 our $LOGROTATE_CONF_FILE = "phplw.conf";

--- a/vagrant_provision/pl/config.pm
+++ b/vagrant_provision/pl/config.pm
@@ -12,13 +12,13 @@ our @LMTOOLS_PATH = (rootdir(), "opt", "lmtools");
 our @HTML_PATH = (rootdir(), "var", "www", "html");
 our @LOGROTATE_PATH = (rootdir(), "etc", "logrotate.d");
 our @APACHE_PATH = (rootdir(), "etc", "apache2");
-our @PHP_INI_DEV_PATH = (rootdir(), "usr", "lib", "php", "7.4");
-our @PHP_INI_APACHE_PATH = (rootdir(), "etc", "php", "7.4", "apache2");
-our @PHP_INI_CLI_PATH = (rootdir(), "etc", "php", "7.4", "cli");
+our @PHP_INI_DEV_PATH = (rootdir(), "usr", "lib", "php", "8.1");
+our @PHP_INI_APACHE_PATH = (rootdir(), "etc", "php", "8.1", "apache2");
+our @PHP_INI_CLI_PATH = (rootdir(), "etc", "php", "8.1", "cli");
 our @CACHE_PATH = (rootdir(), "var", "cache", "phplw");
 
 # Relevant files
-our @CODE_FILES = qw(*.php *.html *.js *.css *.template mathematica);
+our @CODE_FILES = qw(*.php *.html *.js *.css *.template mathematica vendor);
 our $CONFIG_FILE = "config.php";
 our $SQL_FILE = "phplicensewatcher.sql";
 our $LOGROTATE_CONF_FILE = "phplw.conf";
@@ -31,7 +31,7 @@ our $LICENSE_CACHE = "license_cache.php";
 our $COMPOSER_PACKAGES = "vendor";
 
 # Packages needed for phplw.
-our @REQUIRED_PACKAGES = ("apache2", "php", "php-mysql", "mysql-server", "mysql-client", "lsb", "zip", "unzip");
+our @REQUIRED_PACKAGES = ("apache2", "php", "php-mysql", "mysql-server", "mysql-client", "lsb", "wget", "zip", "unzip");
 
 # Non super user account.  Some package systems run better when not as root.
 our $VAGRANT_USER = "vagrant";
@@ -71,6 +71,14 @@ our $DB_CONFIG_FILE = "mysqld.cnf";
 our $DB_NAME = "vagrant";
 our $DB_USER = "vagrant";
 our $DB_PASS = "vagrant";
+
+# Composer
+our $COMPOSER_SIG_URL = "https://composer.github.io/installer.sig";
+our $COMPOSER_SETUP_URL = "https://getcomposer.org/installer";
+our @COMPOSER_SETUP_PATH = @VAGRANT_HOMEPATH;
+our $COMPOSER_SETUP_FILE = "composer_setup.php";
+our @COMPOSER_BIN_PATH = (rootdir(), "usr", "local", "bin");
+our $COMPOSER_BIN_PERMISSIONS = 0755;
 
 # ** -------------------------- END CONFIGURATION --------------------------- **
 

--- a/vagrant_provision/pl/provision.pl
+++ b/vagrant_provision/pl/provision.pl
@@ -319,5 +319,6 @@ sub copy_code {
     print "Copying repository code.\n";
     my @working_path = (@CONFIG::REPO_PATH, "vagrant_provision", "pl");
     my $file = catfile(@working_path, $CONFIG::UPDATE_CODE);
+    exec_cmd("perl ${file} composer-install-packages");
     exec_cmd("perl ${file} full");
 }

--- a/vagrant_provision/pl/provision.pl
+++ b/vagrant_provision/pl/provision.pl
@@ -9,6 +9,7 @@ use autodie;
 use File::Basename qw(fileparse);
 use File::Copy qw(copy);
 use File::Spec::Functions qw(catdir catfile);
+use Digest::file qw(digest_file_hex);
 use FindBin qw($RealBin);
 use lib $RealBin;
 use config;
@@ -26,7 +27,7 @@ setup_database();
 setup_logrotate();
 setup_php();
 setup_apache();
-# setup_composer();  # Composer disabled.
+setup_composer();
 create_symlink();
 copy_code();
 
@@ -255,7 +256,35 @@ sub setup_apache {
 
 # Run composer to retrieve PHP dependencies.  Composer cannot be run as superuser.
 sub setup_composer {
-    exec_cmd("su -c \"composer -d" . catfile(@CONFIG::REPO_PATH) . " install\" $CONFIG::VAGRANT_USER");
+    my $sig_url = $CONFIG::COMPOSER_SIG_URL;
+    my $setup_url = $CONFIG::COMPOSER_SETUP_URL;
+    my $setup_path = catdir(@CONFIG::COMPOSER_SETUP_PATH);
+    my $setup_file = $CONFIG::COMPOSER_SETUP_FILE;
+    my $bin_path = catdir(@CONFIG::COMPOSER_BIN_PATH);
+    my ($sig_hash, $setup_hash, $dest, $permissions);
+
+    print "Setup composer.\n";
+
+    # Get Composer's expected sha-384 hash for setup file.
+    $sig_hash = `wget --quiet --output-document=- ${sig_url}`;
+
+    # Retrieve Composer setup file
+    exec_cmd("wget --directory-prefix=${setup_path} --output-document=${setup_file} ${setup_url}");
+
+    # Get Composer setup file hash
+    $dest = catfile($setup_path, $setup_file);
+    $setup_hash = digest_file_hex($dest, "SHA-384");
+    print "Composer setup file SHA-384 hash\nExpected: ${sig_hash}\nFound:    ${setup_hash}\n";
+
+    # Authenticity check
+    print STDERR "Composer setup file hash mismatch.  Retrieved setup may not be authentic.\nAborting.\n" and exit 1 if ($sig_hash ne $setup_hash);
+
+    # Install Composer
+    $permissions = $CONFIG::COMPOSER_BIN_PERMISSIONS;
+    exec_cmd("php ${dest} --install-dir=${bin_path} --filename=composer");
+    chmod $permissions, $dest;
+
+    print "Composer ready at ${bin_path}/composer\n";
 }
 
 # Create convenient symlink
@@ -273,7 +302,7 @@ sub create_symlink {
     push @scripts, catfile(@CONFIG::HTML_PATH, $CONFIG::LICENSE_UTIL);
     push @scripts, catfile(@CONFIG::HTML_PATH, $CONFIG::LICENSE_CACHE);
     push @scripts, catdir(@CONFIG::DEBUG_PATH);
-    
+
     push @links, catfile(@CONFIG::VAGRANT_HOMEPATH, "update");
     push @links, catfile(@CONFIG::VAGRANT_HOMEPATH, "license_util");
     push @links, catfile(@CONFIG::VAGRANT_HOMEPATH, "license_cache");

--- a/vagrant_provision/pl/update_code.pl
+++ b/vagrant_provision/pl/update_code.pl
@@ -20,21 +20,14 @@ print "Root required.\n" and exit 1 if ($> != 0);
 # CLI arg = full:  remove/reinstall all code and dependencies to HTML directory
 # CLI arg = update-composer:  Run update only on composer dependencies
 # No CLI arg:  (default) copy latest development code to HTML directory
-my ($source, $dest, $file, $composer, @files);
 if (defined $ARGV[0] && $ARGV[0] eq "full") {
     clear_html_folder();
-    $source = catdir(@CONFIG::REPO_PATH);
-    $dest   = catdir(@CONFIG::HTML_PATH);
-    $composer = $CONFIG::COMPOSER_PACKAGES;
-    @files = build_file_list($source);
-    push @files, full_recursive_file_list($composer);
-    print "Install development code.\n";
-    copy_code($source, $dest, @files);
+    install_code();
 
     # Config file copy
-    $source = catdir(@CONFIG::CONFIG_PATH);
-    $dest   = catdir(@CONFIG::HTML_PATH);
-    $file   = $CONFIG::CONFIG_FILE;
+    my $source = catdir(@CONFIG::CONFIG_PATH);
+    my $dest   = catdir(@CONFIG::HTML_PATH);
+    my $file   = $CONFIG::CONFIG_FILE;
     print "Install vagrant config file.\n";
     copy_code($source, $dest, $file);
 } elsif (defined $ARGV[0] && $ARGV[0] eq "composer-install-packages") {
@@ -42,19 +35,14 @@ if (defined $ARGV[0] && $ARGV[0] eq "full") {
 } elsif (defined $ARGV[0] && $ARGV[0] eq "composer-update-packages") {
     composer("update");
 } else {
-    $source = catdir(@CONFIG::REPO_PATH);
-    $dest   = catdir(@CONFIG::HTML_PATH);
-    $composer = $CONFIG::COMPOSER_PACKAGES;
-    @files  = build_file_list($source);
-    push @files, full_recursive_file_list($composer);
-    print "Update development code.\n";
-    copy_code($source, $dest, @files);
+    install_code();
 }
 
 # All done!
 exit 0;
 
 # Run composer to either install or update packages.
+# Expected param: either "install" or "update".
 sub composer {
     my $cmd = shift;
     my $dest = catdir(@CONFIG::REPO_PATH);
@@ -64,7 +52,7 @@ sub composer {
         exit 1;
     }
 
-    print "Composer: $cmd done.\n";
+    print "Composer: ${cmd} done.\n";
 }
 
 # Remove everything from HTML directory
@@ -74,16 +62,40 @@ sub clear_html_folder {
     print "Cleared HTML directory.\n";
 }
 
-# Expected param: $root_path (path to start gathering filenames for code copying)
-# Optional param: $sub_path  Additional dirs off of $root_path.  Default: $sub_path = ""
+# Install code or update existing code in working dir (/var/www/html).
+sub install_code {
+    my $source = catdir(@CONFIG::REPO_PATH);
+    my $dest = catdir(@CONFIG::HTML_PATH);
+    my $composer_subpath = $CONFIG::COMPOSER_PACKAGES;
+    my @code_files = @CONFIG::CODE_FILES;
+    my @composer_files = @CONFIG::COMPOSER_CODE_FILES;
+    my $num_code_files = scalar @code_files;
+    my $num_composer_files = scalar @composer_files;
+    # This build_file_list() call lists out phpLW's own code.
+    my @files = build_file_list($num_code_files, @code_files, $source);
+    # This build_file_list() call lists out code provided by composer.
+    push @files, build_file_list($num_composer_files, @composer_files, $source, $composer_subpath);
+    print "Install/Update development code.\n";
+    copy_code($source, $dest, @files);
+}
+
+# Build a list of code files used by phpLW.  This list is to help ensure that
+# the working dir (/var/www/html) is clean from extraneous files in the repo.
+#
+# Expected params: $n = number of elems expected in @code_files
+#                  @code_files = array of glob patterns for building a file list
+#                  $root_path = dir to start glob search
+#                  $sub_path = (optional) additional dirs off of $root_path
+# Return: List of all files (and paths) that make up phpLW's code.
 sub build_file_list {
+    my $n = shift;
+    my @code_files = splice @_, 0, $n;
     my $root_path = shift;
-    my ($sub_path, $search_path, $path, $file, @file_list);
-
     # Get $sub_path, if param exists.
-    $sub_path = scalar @_ > 0 ? shift : "";
+    my $sub_path = scalar @_ > 0 ? shift : "";
+    my ($search_path, $path, $file, @file_list);
 
-    foreach (@CONFIG::CODE_FILES) {
+    foreach (@code_files) {
         $path = catfile($root_path, $sub_path, $_);
         foreach (glob $path) {
             next if (!-e $_); # Occasionally glob matches to a non-existent file.  Skip those.
@@ -91,36 +103,15 @@ sub build_file_list {
             if (-d $_) {
                 # Recurse into directory and push results onto @file_list
                 $search_path = catdir($sub_path, $file);
-                push @file_list, build_file_list($root_path, $search_path);
-                next;
+                push @file_list, build_file_list($n, @code_files, $root_path, $search_path);
+            } else {
+                $file = catfile($sub_path, $file) if ($sub_path ne "");
+                push @file_list, $file;
             }
-
-            $file = catfile($sub_path, $file) if ($sub_path ne "");
-            push @file_list, $file;
         }
     }
 
     return @file_list;
-}
-
-# Recursive copy of all files in a directory tree. Intended for Composer files in "vendor".
-# Expected param: start dir for copying files (such as "vendor").
-sub full_recursive_file_list {
-    my $path = shift;
-    my $glob_pattern = catdir(@CONFIG::REPO_PATH, $path, "*");
-    my ($file, @files);
-    foreach (glob $glob_pattern) {
-        next if (!-e $_); # Occasionally glob matches to a non-existent file.  Skip those.
-        $file = fileparse($_);
-        $file = catfile($path, $file);
-        if (-d $_) {
-            push @files, full_recursive_file_list($file);
-        } else {
-            push @files, $file;
-        }
-    }
-
-    return @files;
 }
 
 # Copy all code files (other than config files)

--- a/vagrant_provision/pl/update_code.pl
+++ b/vagrant_provision/pl/update_code.pl
@@ -21,7 +21,7 @@ print "Root required.\n" and exit 1 if ($> != 0);
 # No CLI arg:  (default) copy latest development code to HTML directory
 my ($source, $dest, $file, @files);
 if (defined $ARGV[0] && $ARGV[0] eq "full") {
-    # composer("install"); # Composer is disabled.
+    composer("install");
     clear_html_folder();
     $source = catdir(@CONFIG::REPO_PATH);
     $dest   = catdir(@CONFIG::HTML_PATH);
@@ -36,7 +36,7 @@ if (defined $ARGV[0] && $ARGV[0] eq "full") {
     print "Install vagrant config file.\n";
     copy_code($source, $dest, $file);
 } elsif (defined $ARGV[0] && $ARGV[0] eq "update-composer") {
-    # composer("update"); # Composer is disabled.
+    composer("update");
 } else {
     $source = catdir(@CONFIG::REPO_PATH);
     $dest   = catdir(@CONFIG::HTML_PATH);
@@ -49,18 +49,17 @@ if (defined $ARGV[0] && $ARGV[0] eq "full") {
 exit 0;
 
 # Run composer to either install or update packages.
-# Composer is disabled.
-# sub composer {
-#     my $cmd = shift;
-#     my $dest = catdir(@CONFIG::REPO_PATH);
-#
-#     if ((system "su -c \"composer -d$dest $cmd\" $CONFIG::VAGRANT_USER") != 0) {
-#         print STDERR "composer exited ", $? >> 8, "\n";
-#         exit 1;
-#     }
-#
-#     print "Composer: $cmd done.\n";
-# }
+sub composer {
+    my $cmd = shift;
+    my $dest = catdir(@CONFIG::REPO_PATH);
+
+    if ((system "su -c \"composer -d$dest $cmd\" $CONFIG::VAGRANT_USER") != 0) {
+        print STDERR "composer exited ", $? >> 8, "\n";
+        exit 1;
+    }
+
+    print "Composer: $cmd done.\n";
+}
 
 # Remove everything from HTML directory
 sub clear_html_folder {

--- a/vagrantfile
+++ b/vagrantfile
@@ -38,7 +38,8 @@ Vagrant.configure(2) do |config|
     config.vm.synced_folder ".", REPO_PATH, create: true, owner: "vagrant", group: "vagrant", mount_options: ['dmode=775', 'fmode=664']
     config.vm.provision "shell", inline: "perl #{REPO_PATH}/#{PROV_SCRIPT} |& tee #{REPO_PATH}/#{PROV_LOG}", privileged: true, run: "once"
     config.vm.provision "update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT}", privileged: true, run: "never"
-    config.vm.provision "composer-update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT} update-composer ", privileged: true, run: "never"
+    config.vm.provision "composer-install", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT} composer-install-packages ", privileged: true, run: "never"
+    config.vm.provision "composer-update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT} composer-update-packages ", privileged: true, run: "never"
     config.vm.provision "full-update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT} full ", privileged: true, run: "never"
     config.vm.provision "delete-cache", type: "shell", inline: "rm --verbose /var/cache/phplw/*.cache", privileged: true, run: "never"
     config.vm.provision "show-log", type: "shell", inline: "tail /opt/debug/phplw-error.log", privileged: true, run: "never"

--- a/vagrantfile
+++ b/vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure(2) do |config|
     end
 
     config.vm.define "dev_box", primary: true do |phplw|
-        phplw.vm.box = "bento/ubuntu-20.04"
+        phplw.vm.box = "bento/ubuntu-22.04"
         phplw.vm.network "forwarded_port", guest: 80, host: 50080
         phplw.vm.network "forwarded_port", guest: 3306, host: 53306
     end
@@ -38,7 +38,7 @@ Vagrant.configure(2) do |config|
     config.vm.synced_folder ".", REPO_PATH, create: true, owner: "vagrant", group: "vagrant", mount_options: ['dmode=775', 'fmode=664']
     config.vm.provision "shell", inline: "perl #{REPO_PATH}/#{PROV_SCRIPT} |& tee #{REPO_PATH}/#{PROV_LOG}", privileged: true, run: "once"
     config.vm.provision "update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT}", privileged: true, run: "never"
-#   config.vm.provision "composer-update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT} update-composer ", privileged: true, run: "never"
+    config.vm.provision "composer-update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT} update-composer ", privileged: true, run: "never"
     config.vm.provision "full-update", type: "shell", inline: "perl #{REPO_PATH}/#{UPDATE_SCRIPT} full ", privileged: true, run: "never"
     config.vm.provision "delete-cache", type: "shell", inline: "rm --verbose /var/cache/phplw/*.cache", privileged: true, run: "never"
     config.vm.provision "show-log", type: "shell", inline: "tail /opt/debug/phplw-error.log", privileged: true, run: "never"


### PR DESCRIPTION
* Fix #96
* Emailed reports are now authenticated by SMTP using either smtps (aka "ssl/tls") or starttls.
* Updated sample_config.php
* PHPMailer library required, and is setup by Composer.
   * Composer json and lock files included.
* Updated Vagrant testing and development environment for Composer and Ubuntu 22.04.