### PR TITLE
Fix: Features with hyphens in their name won't draw usage charts

### DIFF
--- a/graph_data.php
+++ b/graph_data.php
@@ -3,7 +3,7 @@
 require_once __DIR__ . "/common.php";
 require_once __DIR__ . "/tools.php";
 
-$feature = preg_replace("/[^a-zA-Z0-9_|]+/", "", htmlspecialchars($_GET['feature'])) ;
+$feature = preg_replace("/[^a-zA-Z0-9_|\-]+/", "", htmlspecialchars($_GET['feature'])) ;
 $days = intval($_GET['days']);
 
 $crit = "";

--- a/monitor_detail.php
+++ b/monitor_detail.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . "/common.php";
 
-$feature = preg_replace("/[^a-zA-Z0-9_|]+/", "", htmlspecialchars($_GET['feature'])) ;
+$feature = preg_replace("/[^a-zA-Z0-9_|\-]+/", "", htmlspecialchars($_GET['feature'])) ;
 $label = $feature;
 
 db_connect($db);


### PR DESCRIPTION
Fix Issue #138 

Features with hyphen in their name will now draw usage charts.