### PR TITLE
Fix PHP 8 type-error exception thrown in details.php

### DIFF
--- a/details.php
+++ b/details.php
@@ -188,7 +188,9 @@ function list_licenses_in_use($servers, &$html_body) {
                     ? $license['num_reservations']
                     : 0;
 
-                $licenses_available = $license['num_licenses'] - $licenses_used;
+                $licenses_available = $license['num_licenses'] !== "uncounted" && $licenses_used !== "uncounted"
+                    ? $license['num_licenses'] - $licenses_used
+                    : "uncounted";
 
                 $license_info = "Total of {$license['num_licenses']} licenses, {$licenses_used} currently in use, ";
                 $license_info .= array_key_exists('num_queued', $license) ? "{$license['num_queued']} queued, " : "";
@@ -240,8 +242,8 @@ function list_licenses_in_use($servers, &$html_body) {
                         $table->add_row(array("", "", $html, ""), $class);
                     } // END foreach ($license['reservations'] as $reservation)
                 } // END if (array_key_exists('reservations', $license) && is_countable($license['reservations']))
-             } // END if (!array_key_exists('filter_feature', $_GET) || in_array($license['feature_name'], $_GET['filter_feature']))
-         } // END foreach(array_merge($used_licenses, $unused_licenses) as $i => $license)
+            } // END if (!array_key_exists('filter_feature', $_GET) || in_array($license['feature_name'], $_GET['filter_feature']))
+        } // END foreach(array_merge($used_licenses, $unused_licenses) as $i => $license)
 
         // Display the table
         $html_body .= $table->get_html();

--- a/tools.php
+++ b/tools.php
@@ -274,7 +274,7 @@ function cache_store($command, $data) {
 /**
  * Interpret a DateInterval object into words.
  *
- * DateInterval's format fnuction doesn't give us the power to exclude a
+ * DateInterval's format function doesn't give us the power to exclude a
  * zero value.  e.g. $dti->format("%y year(s), %m month(s), %d day(s).") will
  * always include years, months, and days even when they are zero.  Same
  * goes for hours, minutes, seconds.  This function will exclude zero values.


### PR DESCRIPTION
Close #144 

Fix in PHP 8+
```
PHP Fatal error:  Uncaught TypeError: Unsupported operand types: string - string in /var/www/phplw/details.php:191
Stack trace:
#0 /var/www/phplw/details.php(28): list_licenses_in_use()
#1 {main}
  thrown in /var/www/phplw/details.php on line 191
```



